### PR TITLE
Send audit AdmissionReview request to policy server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,4 @@ unit-tests: fmt vet ## Run unit tests.
 
 build: fmt vet lint ## Build audit-scanner binary.
 	go build -o bin/audit-scanner .
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const defaultKubewardenNamespace = "kubewarden"
+
 // A Scanner verifies that existing resources don't violate any of the policies
 type Scanner interface {
 	// ScanNamespace scans a given namespace
@@ -36,11 +38,15 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 			if err != nil {
 				return err
 			}
+			kubewardenNamespace, err := cmd.Flags().GetString("kubewarden-namespace")
+			if err != nil {
+				return err
+			}
 			policiesFetcher, err := policies.NewFetcher()
 			if err != nil {
 				return err
 			}
-			resourcesFetcher, err := resources.NewFetcher()
+			resourcesFetcher, err := resources.NewFetcher(kubewardenNamespace)
 			if err != nil {
 				return err
 			}
@@ -76,5 +82,6 @@ func startScanner(namespace string, scanner Scanner) error {
 
 func init() {
 	rootCmd.Flags().StringP("namespace", "n", "", "namespace to be evaluated")
+	rootCmd.Flags().StringP("kubewarden-namespace", "k", defaultKubewardenNamespace, "namespace where the Kubewarden components (e.g. Policy Server) are installed (required)")
 	rootCmd.Flags().VarP(&level, "loglevel", "l", fmt.Sprintf("level of the logs. Supported values are: %v", logconfig.SupportedValues))
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9
+	github.com/google/uuid v1.3.0
 	github.com/kubewarden/kubewarden-controller v1.1.2-0.20221021125822-dbf0a01df20e
 	github.com/rs/zerolog v1.28.0
 	github.com/spf13/cobra v1.6.0
@@ -30,7 +31,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/resources/admission_request.go
+++ b/internal/resources/admission_request.go
@@ -1,0 +1,41 @@
+package resources
+
+import (
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func GenerateAdmissionRequest(resource unstructured.Unstructured) *admv1.AdmissionRequest {
+	groupVersionKind := resource.GroupVersionKind()
+	request := admv1.AdmissionRequest{
+		UID:  resource.GetUID(),
+		Name: resource.GetName(),
+		Kind: metav1.GroupVersionKind{
+			Group:   groupVersionKind.Group,
+			Version: groupVersionKind.Version,
+			Kind:    groupVersionKind.Kind,
+		},
+		Resource: metav1.GroupVersionResource{
+			Group:    groupVersionKind.Group,
+			Version:  groupVersionKind.Version,
+			Resource: groupVersionKind.Kind,
+		},
+		Operation: admv1.Create,
+		Namespace: resource.GetNamespace(),
+		Object: runtime.RawExtension{
+			Object: resource.DeepCopyObject(),
+			Raw:    nil,
+		},
+	}
+	return &request
+}
+
+func GenerateAdmissionReview(resource unstructured.Unstructured) *admv1.AdmissionReview {
+	admissionRequest := GenerateAdmissionRequest(resource)
+	return &admv1.AdmissionReview{
+		Request:  admissionRequest,
+		Response: nil,
+	}
+}

--- a/internal/resources/admission_request_test.go
+++ b/internal/resources/admission_request_test.go
@@ -1,0 +1,123 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	admv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const resourceName = "testing-name"
+const resourceNamespace = "testing-namespace"
+
+func generateUnstructuredPodObject() unstructured.Unstructured {
+	groupVersionKind := schema.GroupVersionKind{
+		Group:   "core",
+		Version: "v1",
+		Kind:    "Pod",
+	}
+	uid := types.UID(uuid.New().String())
+	obj := unstructured.Unstructured{}
+	obj.SetGroupVersionKind(groupVersionKind)
+	obj.SetUID(uid)
+	obj.SetName(resourceName)
+	obj.SetNamespace(resourceNamespace)
+	return obj
+}
+
+func TestObjectInAdmissionRequest(t *testing.T) {
+	obj := generateUnstructuredPodObject()
+	admissionRequest := GenerateAdmissionRequest(obj)
+
+	admReqObj := admissionRequest.Object.Object
+	if admReqObj.GetObjectKind().GroupVersionKind().Group != obj.GroupVersionKind().Group {
+		t.Errorf("Object group diverge")
+	}
+	if admReqObj.GetObjectKind().GroupVersionKind().Version != obj.GroupVersionKind().Version {
+		t.Errorf("Object version diverge")
+	}
+	if admReqObj.GetObjectKind().GroupVersionKind().Kind != obj.GroupVersionKind().Kind {
+		t.Errorf("Object Kind diverge")
+	}
+}
+
+func TestBasicInfoInAdmissionRequest(t *testing.T) {
+	obj := generateUnstructuredPodObject()
+	admissionRequest := GenerateAdmissionRequest(obj)
+
+	if admissionRequest.Kind.Group != obj.GroupVersionKind().Group {
+		t.Errorf("Group diverge")
+	}
+	if admissionRequest.Kind.Kind != obj.GroupVersionKind().Kind {
+		t.Errorf("Kind diverge")
+	}
+	if admissionRequest.Kind.Version != obj.GroupVersionKind().Version {
+		t.Errorf("Version diverge")
+	}
+	if admissionRequest.UID != obj.GetUID() {
+		t.Errorf("UID diverge")
+	}
+	if admissionRequest.Name != resourceName {
+		t.Errorf("Name diverge")
+	}
+	if admissionRequest.Resource.Group != obj.GroupVersionKind().Group {
+		t.Errorf("Resource Group diverge")
+	}
+	if admissionRequest.Resource.Resource != obj.GroupVersionKind().Kind {
+		t.Errorf("Resource diverge")
+	}
+	if admissionRequest.Resource.Version != obj.GroupVersionKind().Version {
+		t.Errorf("Resource version diverge")
+	}
+	if admissionRequest.Namespace != resourceNamespace {
+		t.Errorf("Namespace diverge")
+	}
+	if admissionRequest.Operation != admv1.Create {
+		t.Errorf("Operation diverge")
+	}
+}
+
+func TestGetAdmissinReview(t *testing.T) {
+	obj := generateUnstructuredPodObject()
+	admissionReview := GenerateAdmissionReview(obj)
+
+	if admissionReview.Response != nil {
+		t.Fatalf("Response should not be set")
+	}
+
+	admissionRequest := admissionReview.Request
+
+	if admissionRequest.Kind.Group != obj.GroupVersionKind().Group {
+		t.Errorf("Group diverge")
+	}
+	if admissionRequest.Kind.Kind != obj.GroupVersionKind().Kind {
+		t.Errorf("Kind diverge")
+	}
+	if admissionRequest.Kind.Version != obj.GroupVersionKind().Version {
+		t.Errorf("Version diverge")
+	}
+	if admissionRequest.UID != obj.GetUID() {
+		t.Errorf("UID diverge")
+	}
+	if admissionRequest.Name != resourceName {
+		t.Errorf("Name diverge")
+	}
+	if admissionRequest.Resource.Group != obj.GroupVersionKind().Group {
+		t.Errorf("Resource Group diverge")
+	}
+	if admissionRequest.Resource.Resource != obj.GroupVersionKind().Kind {
+		t.Errorf("Resource diverge")
+	}
+	if admissionRequest.Resource.Version != obj.GroupVersionKind().Version {
+		t.Errorf("Resource version diverge")
+	}
+	if admissionRequest.Namespace != resourceNamespace {
+		t.Errorf("Namespace diverge")
+	}
+	if admissionRequest.Operation != admv1.Create {
+		t.Errorf("Operation diverge")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,13 +1,21 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 
 	"github.com/kubewarden/audit-scanner/internal/resources"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	admv1 "k8s.io/api/admission/v1"
 )
 
 // A PoliciesFetcher interacts with the kubernetes api to return Kubewarden policies
@@ -20,17 +28,21 @@ type PoliciesFetcher interface {
 
 type ResourcesFetcher interface {
 	GetResourcesForPolicies(ctx context.Context, policies []policiesv1.Policy, namespace string) ([]resources.AuditableResources, error)
+	// GetPolicyServerURLRunningPolicy gets the URL used to send API requests to the policy server
+	GetPolicyServerURLRunningPolicy(ctx context.Context, policy policiesv1.Policy) (*url.URL, error)
 }
 
 // A Scanner verifies that existing resources don't violate any of the policies
 type Scanner struct {
 	policiesFetcher  PoliciesFetcher
 	resourcesFetcher ResourcesFetcher
+	// http client used to make requests against the Policy Server
+	httpClient http.Client
 }
 
 // NewScanner creates a new scanner with the PoliciesFetcher provided
 func NewScanner(policiesFetcher PoliciesFetcher, resourcesFetcher ResourcesFetcher) *Scanner {
-	return &Scanner{policiesFetcher, resourcesFetcher}
+	return &Scanner{policiesFetcher, resourcesFetcher, http.Client{}}
 }
 
 // ScanNamespace scans resources for a given namespace
@@ -44,9 +56,9 @@ func (s *Scanner) ScanNamespace(namespace string) error {
 	log.Debug().Str("namespace", namespace).Int("count", len(policies)).Msg("number of policies to evaluate")
 
 	// TODO continue with the scanning and remove this code
-	fmt.Println("The following policies were found for the namespace " + namespace)
+	log.Debug().Str("namespace", namespace).Msg("The following policies were found for the namespace " + namespace)
 	for _, policy := range policies {
-		fmt.Println(policy.GetName())
+		log.Debug().Str("policy name", policy.GetName()).Msg("Policy retrieved")
 	}
 
 	auditableResources, err := s.resourcesFetcher.GetResourcesForPolicies(context.Background(), policies, namespace)
@@ -57,24 +69,89 @@ func (s *Scanner) ScanNamespace(namespace string) error {
 
 	// TODO this is for debugging, it should be remove in future steps!
 	for _, resource := range auditableResources {
-		fmt.Println("Policies: ")
+		log.Debug().Msg("Policies: ")
 		for _, policy := range resource.Policies {
-			fmt.Println(policy.GetName())
+			url, err := s.resourcesFetcher.GetPolicyServerURLRunningPolicy(context.Background(), policy)
+			if err != nil {
+				log.Debug().Err(err).Msg("CANNOT GET POLICY SERVER URL")
+				continue
+			}
+			log.Debug().Msgf("POLICY SERVER URL: %s", url.String())
 		}
 		for _, resource := range resource.Resources {
-			fmt.Println(resource)
-			fmt.Println("........")
+			log.Debug().Dict("resource", zerolog.Dict().
+				Str("name", resource.GetName()).
+				Str("kind", resource.GetKind()).
+				Str("namespace", resource.GetNamespace()).
+				Str("UID", string(resource.GetUID()))).
+				Msg("auditable resource")
 		}
-		fmt.Println("---------------------")
 	}
 
-	// TODO for next steps:
 	// Iterate through all auditableResources. Each item contains a list of resources and the policies that would need
-	// to evaluate them. You need to create the AdmissionReview request using the resource which is an unstructured.
-	// unstructured nested functions might help with that https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
-	// or the UnstructuredContent() method that returns a map
+	// to evaluate them.
+	for i := range auditableResources {
+		auditResource(&auditableResources[i], &s.resourcesFetcher, &s.httpClient)
+	}
 
 	return nil
+}
+
+// auditResource sends the requests to the Policy Server to evaluate the auditable resources.
+// It will iterate over the policies which should evaluate the resource, get the URL to the service of the policy
+// server running the policy, creates the AdmissionReview payload and send the request to the policy server for evaluation
+func auditResource(resource *resources.AuditableResources, resourcesFetcher *ResourcesFetcher, httpClient *http.Client) {
+	for _, policy := range resource.Policies {
+		url, err := (*resourcesFetcher).GetPolicyServerURLRunningPolicy(context.Background(), policy)
+		if err != nil {
+			// TODO what's the better thing to do here?
+			log.Error().Err(err)
+			continue
+		}
+		for _, resource := range resource.Resources {
+			admissionRequest := resources.GenerateAdmissionReview(resource)
+			auditResponse, err := sendAdmissionReviewToPolicyServer(url, admissionRequest, httpClient)
+			if err != nil {
+				// TODO what's the better thing to do here?
+				log.Error().Err(err)
+				continue
+			}
+
+			log.Debug().Dict("response", zerolog.Dict().
+				Str("uid", string(auditResponse.Response.UID)).
+				Bool("allowed", auditResponse.Response.Allowed)).
+				Msg("audit review response")
+		}
+	}
+}
+
+func sendAdmissionReviewToPolicyServer(url *url.URL, admissionRequest *admv1.AdmissionReview, httpClient *http.Client) (*admv1.AdmissionReview, error) {
+	payload, err := json.Marshal(admissionRequest)
+
+	if err != nil {
+		return nil, err
+	}
+	// TODO remove the following line and properly configure the certificates
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, url.String(), bytes.NewBuffer(payload))
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read body of response: %w", err)
+	}
+	if res.StatusCode > 299 {
+		return nil, fmt.Errorf("response failed with status code: %d and\nbody: %s", res.StatusCode, body)
+	}
+	admissionReview := admv1.AdmissionReview{}
+	err = json.Unmarshal(body, &admissionReview)
+	if err != nil {
+		return nil, fmt.Errorf("cannot deserialize the audit review response: %w", err)
+	}
+	return &admissionReview, nil
 }
 
 // ScanAllNamespaces scans resources for all namespaces

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,0 +1,81 @@
+package scanner
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const auditURL = "http://localhost:9876/audit/"
+
+func startServer() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/audit/", func(response http.ResponseWriter, req *http.Request) {
+		_, err := io.Copy(response, req.Body)
+		if err != nil {
+			fmt.Fprintf(response, "Cannot write the response")
+		}
+	})
+	mux.HandleFunc("/", func(response http.ResponseWriter, req *http.Request) {
+		// The "/" pattern matches everything, so we need to check
+		// that we're at the root here.
+		if req.URL.Path != "/" {
+			http.NotFound(response, req)
+			return
+		}
+		fmt.Fprintf(response, "Welcome to the home page!")
+	})
+	err := http.ListenAndServe("localhost:9876", mux) //nolint
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func TestSendRequestToPolicyServer(t *testing.T) {
+	go startServer()
+
+	admRequest := admv1.AdmissionRequest{
+		UID:  "uid",
+		Name: "name",
+		Kind: metav1.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "pod",
+		},
+		Resource: metav1.GroupVersionResource{
+			Group:    "",
+			Version:  "v1",
+			Resource: "pod",
+		},
+		Operation: admv1.Create,
+		Namespace: "namespace",
+	}
+	admReview := admv1.AdmissionReview{
+		Request:  &admRequest,
+		Response: nil,
+	}
+	url, err := url.Parse(auditURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := sendAdmissionReviewToPolicyServer(url, &admReview, &http.Client{})
+	if err != nil && response == nil {
+		t.Fatal(err)
+	}
+	admissionRequest := response.Request
+
+	if admissionRequest.Kind.Group != "" {
+		t.Errorf("Group diverge")
+	}
+	if admissionRequest.Kind.Kind != "pod" {
+		t.Errorf("Kind diverge")
+	}
+	if admissionRequest.Kind.Version != "v1" {
+		t.Errorf("Version diverge")
+	}
+}


### PR DESCRIPTION
## Description

Updates the audit scanner to send the AdmissionReview built with the previously fetched resources to the policy server.


Fix #10 

## Test

```shell
make unit-tests
```

To run in a actual cluster follow the step defined [here](https://github.com/kubewarden/audit-scanner/pull/2) and then run this code. If you want to run the scanner using a Kubernetes deployment these are some example of the files you can use:

RBAC used to run the deployment:

```yaml
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: audit-scanner
  namespace: kubewarden
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: kubewarden-audit-scanner
rules:
- apiGroups:
    - ""
  resources:
    - "*"
  verbs:
    - list
    - get
    - watch
- apiGroups:
    - "apps"
  resources:
    - "*"
  verbs:
    - list
    - get
    - watch
- apiGroups:
  - "policies.kubewarden.io"
  resources:
    - clusteradmissionpolicies
    - admissionpolicies
    - policyservers
  verbs:
    - list
    - get
    - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: kubewarden-audit-scanner-watcher
subjects:
- kind: ServiceAccount
  name: audit-scanner
  namespace: kubewarden
roleRef:
  kind: ClusterRole
  name: kubewarden-audit-scanner
  apiGroup: rbac.authorization.k8s.io
```

Audit scanner deployment:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: audit-scanner-deployment
  namespace: kubewarden
  labels:
    app: template-scanner
spec:
  replicas: 1
  selector:
    matchLabels:
      app: template-scanner
  template:
    metadata:
      labels:
        app: template-scanner
    spec:
      serviceAccountName: audit-scanner
      containers:
      - name: scanner
        args:
          - -n
          - default
          - -l
          - trace
        image: ghcr.io/jvanz/audit-scanner:mvp3
        imagePullPolicy: Always
```
