### PR TITLE
feat: Save reports to cluster, add new `--print` flag to print them as JSON

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-### Testing localy
+### Testing locally
 
 Install Kubewarden stack normally. For now:
 
@@ -24,9 +24,27 @@ helm upgrade -i --wait \
 kubectl port-forward -n kubewarden service/policy-server-default 3000:8443
 ```
 
+Install PolicyReports CRDs:
+```
+kubectl apply \
+  -f config/crd/wgpolicyk8s.io_clusterpolicyreports.yaml \
+  -f config/crd/wgpolicyk8s.io_policyreports.yaml
+```
+
 Then:
 
+``` console
+./bin/audit-scanner \
+  -k kubewarden --namespace default \
+  --policy-server-url https://localhost:3000 \
+  -l debug
+```
+
+or to get results in JSON:
 
 ``` console
-./bin/audit-scanner -k kubewarden --namespace default -l debug --policy-server-url https://localhost:3000
+./bin/audit-scanner \
+  -k kubewarden --namespace default \
+  --policy-server-url https://localhost:3000 \
+  -l debug --print
 ```

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@
 > **Note well:** don't forget to checkout [Kubewarden's documentation](https://docs.kubewarden.io)
 > for more information
 
-The Audit scanner inspects the resources already deployed in the cluster and
-flags when something violates some policies installed in the cluster.
+The Audit scanner inspects the resources defined in the cluster and
+identifies the ones that are violating Kubewarden policies.
+
+The results of the scan are made available via `PolicyReport` objects. Each Namespace
+has its own dedicated `PolicyReport`. Cluster-wide resources compliance is available via
+the `ClusterPolicyReport` resource. 
 
 # Deployment
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
+## Audit scanner
 
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kubewarden-controller)](https://artifacthub.io/packages/helm/kubewarden/kubewarden-controller)
+<!-- [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6626/badge)](https://bestpractices.coreinfrastructure.org/projects/6626) -->
+<!-- [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Faudit-scanner.svg?type=shield)](https://app.fossa.com/projects/custom%2B25850%2Fgithub.com%2Fkubewarden%2Faudit-scanner?ref=badge_shield) -->
+
+> **Note well:** don't forget to checkout [Kubewarden's documentation](https://docs.kubewarden.io)
+> for more information
+
+The Audit scanner inspects the resources already deployed in the cluster and
+flags when something violates some policies installed in the cluster.
+
+# Deployment
+
+We recommend to rely on the [kubewarden-controller](https://github.com/kubewarden/kubewarden-controller)
+and the [Kubernetes Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+provided by it to deploy the Kubewarden stack.
+
+# Building
+
+You can use the container image we maintain inside of our
+[GitHub Container Registry](https://github.com/orgs/kubewarden/packages/container/package/audit-scanner).
+
+Alternatively, the `audit-scanner` binary can be built in this way:
+
+```shell
+$ make build
+```
+
+Have a look at CONTRIBUTING.md for more developer information.
+
+For implementation details, see [RFC-11](https://github.com/kubewarden/rfc/blob/main/rfc/0011-audit-checks.md), 
+[RFC-12](https://github.com/kubewarden/rfc/blob/main/rfc/0011-audit-checks.md).
+
+
+# Software bill of materials
+
+Audit scanner has its software bill of materials (SBOM) published every release.
+It follows the [SPDX](https://spdx.dev/) version 2.2 format and it can be found
+together with the signature and certificate used to signed it in the
+[release assets](https://github.com/kubewarden/audit-scanner/releases)
+
+
+# Security
+
+The Kubewarden team is security conscious. You can find our [threat model
+assessment](https://docs.kubewarden.io/security/threat-model) and
+[responsible disclosure approach](https://docs.kubewarden.io/security/disclosure)
+in our Kubewarden docs.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ make build
 Have a look at CONTRIBUTING.md for more developer information.
 
 For implementation details, see [RFC-11](https://github.com/kubewarden/rfc/blob/main/rfc/0011-audit-checks.md), 
-[RFC-12](https://github.com/kubewarden/rfc/blob/main/rfc/0011-audit-checks.md).
+[RFC-12](https://github.com/kubewarden/rfc/blob/main/rfc/0012-policy-report.md).
 
 
 # Software bill of materials

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,9 @@ type Scanner interface {
 
 var level logconfig.Level
 
+// print result of scan as JSON to stdout
+var printJSON bool
+
 // rootCmd represents the base command when called without any subcommands
 var (
 	rootCmd = &cobra.Command{
@@ -54,7 +57,7 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 			if err != nil {
 				return err
 			}
-			scanner, err := scanner.NewScanner(policiesFetcher, resourcesFetcher)
+			scanner, err := scanner.NewScanner(policiesFetcher, resourcesFetcher, printJSON)
 			if err != nil {
 				return err
 			}
@@ -88,6 +91,7 @@ func startScanner(namespace string, scanner Scanner) error {
 func init() {
 	rootCmd.Flags().StringP("namespace", "n", "", "namespace to be evaluated")
 	rootCmd.Flags().StringP("kubewarden-namespace", "k", defaultKubewardenNamespace, "namespace where the Kubewarden components (e.g. Policy Server) are installed (required)")
-	rootCmd.Flags().StringP("policy-server-url", "p", "", "Full URL to the PolicyServers, for example https://localhost:3000. Audit scanner will query the needed HTTP path. Useful for out-of-cluster debugging")
+	rootCmd.Flags().StringP("policy-server-url", "u", "", "Full URL to the PolicyServers, for example https://localhost:3000. Audit scanner will query the needed HTTP path. Useful for out-of-cluster debugging")
 	rootCmd.Flags().VarP(&level, "loglevel", "l", fmt.Sprintf("level of the logs. Supported values are: %v", logconfig.SupportedValues))
+	rootCmd.Flags().BoolVarP(&printJSON, "print", "p", false, "print result of scan in JSON to stdout")
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubewarden/audit-scanner/internal/constants"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	admv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -87,6 +88,14 @@ func (r *PolicyReport) AddResult(policy policiesv1.Policy, resource unstructured
 		r.Summary.Pass++
 	}
 	r.Results = append(r.Results, result)
+	log.Debug().
+		Str("report name", r.Name).
+		Dict("result", zerolog.Dict().
+			Str("policy", policy.GetName()).
+			Str("resource", resource.GetName()).
+			Bool("allowed", auditResponse.Response.Allowed).
+			Str("result", string(result.Result)),
+		).Msg("added result to report")
 }
 
 func (r *ClusterPolicyReport) AddResult(policy policiesv1.Policy, resource unstructured.Unstructured, auditResponse *admv1.AdmissionReview, responseErr error) {
@@ -100,6 +109,14 @@ func (r *ClusterPolicyReport) AddResult(policy policiesv1.Policy, resource unstr
 		r.Summary.Pass++
 	}
 	r.Results = append(r.Results, result)
+	log.Debug().
+		Str("report name", r.Name).
+		Dict("result", zerolog.Dict().
+			Str("policy", policy.GetName()).
+			Str("resource", resource.GetName()).
+			Bool("allowed", auditResponse.Response.Allowed).
+			Str("result", string(result.Result)),
+		).Msg("added result to report")
 }
 
 func newPolicyReportResult(policy policiesv1.Policy, resource unstructured.Unstructured, auditResponse *admv1.AdmissionReview, responseErr error) *v1alpha2.PolicyReportResult {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,53 @@
+package report
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubewarden/audit-scanner/internal/constants"
+	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestAddResult(t *testing.T) {
+	report := NewClusterPolicyReport("clusterwide")
+	admReviewPass := admv1.AdmissionReview{
+		Request: &admv1.AdmissionRequest{},
+		Response: &admv1.AdmissionResponse{
+			UID:     "4264aa6a-2d4a-49e6-aed8-156d74678dde",
+			Allowed: true,
+		},
+	}
+	admReviewFail := admv1.AdmissionReview{
+		Request: &admv1.AdmissionRequest{},
+		Response: &admv1.AdmissionResponse{
+			UID:     "4264aa6a-2d4a-49e6-aed8-156d74678dde",
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "failed, policy-server did boom",
+			},
+		},
+	}
+	policy := policiesv1.ClusterAdmissionPolicy{}
+	policy.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constants.KubewardenPoliciesGroup,
+		Version: constants.KubewardenPoliciesVersion,
+		Kind:    constants.KubewardenKindClusterAdmissionPolicy,
+	})
+
+	report.AddResult(&policy, unstructured.Unstructured{}, &admReviewPass, nil)
+	if report.Summary.Pass != 1 {
+		t.Errorf("expected Summary.Pass == 1")
+	}
+	report.AddResult(&policy, unstructured.Unstructured{}, &admReviewFail, nil)
+	if report.Summary.Fail != 1 {
+		t.Errorf("expected Summary.Fail == 1")
+	}
+	report.AddResult(&policy, unstructured.Unstructured{}, &admReviewFail, errors.New("boom"))
+	if report.Summary.Error != 1 {
+		t.Errorf("expected Summary.Error == 1")
+	}
+}

--- a/internal/report/store.go
+++ b/internal/report/store.go
@@ -192,15 +192,27 @@ func (s *PolicyReportStore) SavePolicyReport(report *PolicyReport) error {
 	}, result)
 	// Create new Policy Report if not found
 	if errorMachinery.IsNotFound(getErr) {
-		log.Debug().Msg("creating PolicyReport")
+		log.Debug().
+			Dict("dict", zerolog.Dict().
+				Str("report name", report.Name).Str("report ns", report.Namespace),
+			).
+			Msg("creating PolicyReport")
 		err := s.client.Create(context.TODO(), &report.PolicyReport)
 		if err != nil {
 			return fmt.Errorf("create failed: %w", err)
 		}
-		log.Info().Msg("created PolicyReport")
+		log.Info().
+			Dict("dict", zerolog.Dict().
+				Str("report name", report.Name).Str("report ns", report.Namespace),
+			).
+			Msg("created PolicyReport")
 	} else {
 		// Update existing Policy Report
-		log.Debug().Msg("updating PolicyReport")
+		log.Debug().
+			Dict("dict", zerolog.Dict().
+				Str("report name", report.Name).Str("report ns", report.Namespace),
+			).
+			Msg("updating PolicyReport")
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			getObj := &polReport.PolicyReport{}
 			err := s.client.Get(context.TODO(), types.NamespacedName{
@@ -225,7 +237,8 @@ func (s *PolicyReportStore) SavePolicyReport(report *PolicyReport) error {
 		log.Info().
 			Dict("dict", zerolog.Dict().
 				Str("report name", report.Name).Str("report ns", report.Namespace),
-			).Msg("updated PolicyReport")
+			).
+			Msg("updated PolicyReport")
 	}
 	return nil
 }

--- a/internal/report/store.go
+++ b/internal/report/store.go
@@ -160,11 +160,13 @@ func (s *PolicyReportStore) ToJSON() (string, error) {
 // SaveAll saves the store policy reports to the cluster. It does this by
 // instantiating new clusterPolicyReport and PolicyReports, or updating them if
 // they are already present.
-func (s *PolicyReportStore) SaveAll() {
+func (s *PolicyReportStore) SaveAll() error {
+	var errs error
 	if err := s.SaveClusterPolicyReport(); err != nil {
 		log.Error().Err(err).
 			Str("report name", s.clusterPolicyReport.GetName()).
 			Msg("error saving ClusterPolicyReport")
+		errs = errors.New(errs.Error() + err.Error())
 	}
 
 	for _, report := range s.namespacedPolicyReports {
@@ -173,8 +175,10 @@ func (s *PolicyReportStore) SaveAll() {
 			log.Error().Err(err).
 				Str("report name", report.GetName()).
 				Msg("error saving PolicyReport")
+			errs = errors.New(errs.Error() + err.Error())
 		}
 	}
+	return errs
 }
 
 // SavePolicyReport instantiates the passed namespaced PolicyReport if it doesn't exist, or

--- a/internal/report/store_test.go
+++ b/internal/report/store_test.go
@@ -1,10 +1,14 @@
 package report_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kubewarden/audit-scanner/internal/report"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 
@@ -32,7 +36,7 @@ var npr = report.PolicyReport{
 }
 
 func Test_PolicyReportStore(t *testing.T) {
-	store := report.MockNewPolicyReportStore()
+	store := report.MockNewPolicyReportStore(nil)
 
 	t.Run("Add then Get namespaced PolicyReport", func(t *testing.T) {
 		_, err := store.GetPolicyReport(npr.GetNamespace())
@@ -132,6 +136,85 @@ func Test_PolicyReportStore(t *testing.T) {
 		r2, _ := store.GetClusterPolicyReport()
 		if r2.Summary.Skip != 1 {
 			t.Errorf("Expected Summary.Skip to be 1 after update")
+		}
+	})
+}
+
+func TestSaveReports(t *testing.T) {
+	customScheme := scheme.Scheme
+	customScheme.AddKnownTypes(
+		v1alpha2.SchemeGroupVersion,
+		&v1alpha2.PolicyReport{},
+		&v1alpha2.ClusterPolicyReport{},
+		&v1alpha2.PolicyReportList{},
+		&v1alpha2.ClusterPolicyReportList{},
+	)
+	//nolint
+	// fake client has been undeprecated due to overwhemling feedback
+	// https://github.com/kubernetes-sigs/controller-runtime/pull/1101
+	cl := fake.NewFakeClientWithScheme(customScheme, &npr.PolicyReport, &cpr.ClusterPolicyReport)
+	store := report.MockNewPolicyReportStore(cl)
+
+	t.Run("Save ClusterPolicyReport (update)", func(t *testing.T) {
+		if err := store.SaveClusterPolicyReport(); err != nil {
+			// always updates ClusterPolicyReport, store initializes with blank
+			// ClusterPolicReport
+			t.Errorf("Should not return errors")
+		}
+	})
+
+	t.Run("Save PolicyReport (update)", func(t *testing.T) {
+		upr := report.PolicyReport{
+			v1alpha2.PolicyReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "polr-ns-test",
+					Namespace:         "test",
+					CreationTimestamp: metav1.Now(),
+				},
+				Summary: v1alpha2.PolicyReportSummary{Skip: 1},
+				Results: []*v1alpha2.PolicyReportResult{},
+			},
+		}
+
+		if err := store.SavePolicyReport(&upr); err != nil {
+			t.Errorf("Should not return errors")
+		}
+		getObj := &v1alpha2.PolicyReport{}
+		getErr := cl.Get(context.TODO(), types.NamespacedName{
+			Namespace: npr.Namespace,
+			Name:      npr.Name,
+		}, getObj)
+		if getErr != nil {
+			t.Errorf("Should not return errors")
+		}
+		if getObj.Summary.Skip != 1 {
+			t.Errorf("Expected Summary.Skip to be 1 after update")
+		}
+	})
+
+	t.Run("Save PolicyReport (create)", func(t *testing.T) {
+		npr2 := report.PolicyReport{
+			v1alpha2.PolicyReport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "polr-ns-test2",
+					Namespace:         "test",
+					CreationTimestamp: metav1.Now(),
+				},
+				Summary: v1alpha2.PolicyReportSummary{},
+				Results: []*v1alpha2.PolicyReportResult{},
+			},
+		}
+
+		if err := store.SavePolicyReport(&npr2); err != nil {
+			t.Errorf("Should not return errors")
+		}
+		getObj := &v1alpha2.PolicyReport{}
+		getErr := cl.Get(context.TODO(), types.NamespacedName{
+			Namespace: npr2.Namespace,
+			Name:      npr2.Name,
+		}, getObj)
+		if getErr != nil {
+			t.Errorf("Should not return errors")
 		}
 	})
 }

--- a/internal/resources/fetcher.go
+++ b/internal/resources/fetcher.go
@@ -180,7 +180,11 @@ func (f *Fetcher) GetPolicyServerURLRunningPolicy(ctx context.Context, policy po
 	}
 	var urlStr string
 	if f.policyServerURL != "" {
-		urlStr = fmt.Sprintf("%s/audit/%s", f.policyServerURL, policy.GetUniqueName())
+		url, err := url.Parse(f.policyServerURL)
+		if err != nil {
+			log.Fatal().Msg("incorrect URL for policy-server")
+		}
+		urlStr = fmt.Sprintf("%s/audit/%s", url, policy.GetUniqueName())
 	} else {
 		urlStr = fmt.Sprintf("https://%s.%s.svc:%d/audit/%s", service.Name, f.kubewardenNamespace, service.Spec.Ports[0].Port, policy.GetUniqueName())
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -95,7 +95,12 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 			log.Error().Err(err).Msg("error adding PolicyReport to store")
 		}
 	}
+	log.Info().Str("namespace", nsName).Msg("scan finished")
 
+	err = s.reportStore.SaveAll()
+	if err != nil {
+		return err
+	}
 	// TODO for debug
 	str, err := s.reportStore.ToJSON()
 	fmt.Println(str)
@@ -103,7 +108,6 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 		log.Error().Err(err).Msg("error marshaling reportStore to JSON")
 	}
 
-	log.Info().Str("namespace", nsName).Msg("scan finished")
 	return nil
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -106,9 +106,7 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 		fmt.Println(str)
 	}
 
-	s.reportStore.SaveAll()
-
-	return nil
+	return s.reportStore.SaveAll()
 }
 
 // auditResource sends the requests to the Policy Server to evaluate the auditable resources.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -124,7 +124,7 @@ func auditResource(resource *resources.AuditableResources, resourcesFetcher *Res
 			admissionRequest := resources.GenerateAdmissionReview(resource)
 			auditResponse, responseErr := sendAdmissionReviewToPolicyServer(url, admissionRequest, httpClient)
 			if responseErr != nil {
-				// log error, will end in PolicyReportResult too
+				// log responseErr, will end in PolicyReportResult too
 				log.Error().Err(responseErr).Dict("response", zerolog.Dict().
 					Str("admissionRequest name", admissionRequest.Request.Name).
 					Str("policy", policy.GetName()).
@@ -134,9 +134,9 @@ func auditResource(resource *resources.AuditableResources, resourcesFetcher *Res
 			} else {
 				log.Debug().Dict("response", zerolog.Dict().
 					Str("uid", string(auditResponse.Response.UID)).
-					Bool("allowed", auditResponse.Response.Allowed).
 					Str("policy", policy.GetName()).
-					Str("resource", resource.GetName()),
+					Str("resource", resource.GetName()).
+					Bool("allowed", auditResponse.Response.Allowed),
 				).
 					Msg("audit review response")
 				nsReport.AddResult(policy, resource, auditResponse, responseErr)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -106,10 +106,7 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 		fmt.Println(str)
 	}
 
-	err = s.reportStore.SaveAll()
-	if err != nil {
-		return err
-	}
+	s.reportStore.SaveAll()
 
 	return nil
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/36

Save all reports to cluster.
Add a new `--print` flag: these flag prints the results to stdout as JSON, in addition to what the audit-scanner is doing.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested manually against cluster, see CONTRIBUTING.md.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

This PR could include the first e2e tests for audit scanner (mocking policy-server). We also have k8s e2e tests listed as a different task on the epic.