### PR TITLE
ci: Ship CRDS.tar.gz as part of GH releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
             }
             core.setFailed(`Draft release not found`)
 
+      - name: tar CRDs
+        run: |
+          tar -czf CRDS.tar.gz -C config/crd $(ls config/crd)
+
       - name: Upload release assets
         id: upload_release_assets
         uses: actions/github-script@v6
@@ -142,4 +146,4 @@ jobs:
       #     token: ${{ secrets.HELM_CHART_REPO_ACCESS_TOKEN }}
       #     repository: "${{github.repository_owner}}/helm-charts"
       #     event-type: update-chart
-      #     client-payload: '{"version": "${{ github.ref_name }}", "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}", "repository": "${{ github.repository }}"}'
+      #     client-payload: '{"version": "${{ github.ref_name }}", "oldVersion": "${{ steps.get_last_release_tag.outputs.old_release_tag }}", "repository": "${{ github.repository }}", "crds_asset_id": "${{steps.upload_release_assets.outputs.crds_asset_id}}"}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,25 @@
-.idea
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
 bin
+testbin/*
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+
+CRDS.tar.gz


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Partially implements https://github.com/kubewarden/audit-scanner/issues/45

ci: Ship CRDS.tar.gz as part of GH releases. The file `CRDS.tar.gz` is already shipped if existing, but before this PR it didn't exist.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Untested. I can make a release in my fork against main, but I would need https://github.com/kubewarden/audit-scanner/pull/42 merged so I have viccuad/main clear :sweat_smile: .

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
