### PR TITLE
feat: Set PolicyReportResult fields

### DIFF
--- a/.github/workflows/reusable-container-image.yml
+++ b/.github/workflows/reusable-container-image.yml
@@ -102,6 +102,11 @@ jobs:
           tags: |
             ghcr.io/${{github.repository_owner}}/audit-scanner:${{ env.TAG_NAME }}
       -
+        name: Test container image
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          docker run --rm ghcr.io/${{ github.repository_owner }}/audit-scanner:${{ env.TAG_NAME }} --help
+      -
         name: Create SBOM file
         if: ${{ inputs.generate-sbom == true }}
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BIN_DIR := $(abspath $(ROOT_DIR)/bin)
+IMG ?= audit-scanner:latest
 
 GOLANGCI_LINT_VER := v1.52.2
 GOLANGCI_LINT_BIN := golangci-lint
@@ -26,3 +27,6 @@ unit-tests: fmt vet ## Run unit tests.
 build: fmt vet lint ## Build audit-scanner binary.
 	go build -o bin/audit-scanner .
 
+.PHONY: docker-build
+docker-build: unit-tests
+	docker build -t ${IMG} .

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,6 +1,8 @@
 package report
 
 import (
+	"encoding/json"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
@@ -96,6 +98,22 @@ func (r *PolicyReport) AddResult(policy policiesv1.Policy, resource unstructured
 			Bool("allowed", auditResponse.Response.Allowed).
 			Str("result", string(result.Result)),
 		).Msg("added result to report")
+}
+
+func (r *PolicyReport) GetSummary() (string, error) {
+	marshaled, err := json.Marshal(r.Summary)
+	if err != nil {
+		return "error marshalling summary", err
+	}
+	return string(marshaled), nil
+}
+
+func (r *ClusterPolicyReport) GetSummary() (string, error) {
+	marshaled, err := json.Marshal(r.Summary)
+	if err != nil {
+		return "error marshalling summary", err
+	}
+	return string(marshaled), nil
 }
 
 func (r *ClusterPolicyReport) AddResult(policy policiesv1.Policy, resource unstructured.Unstructured, auditResponse *admv1.AdmissionReview, responseErr error) {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -129,7 +129,8 @@ func (r *PolicyReport) GetSummaryJSON() (string, error) {
 	return string(marshaled), nil
 }
 
-func (r *ClusterPolicyReport) GetSummary() (string, error) {
+// GetSummaryJSON gets the report.Summary formatted in JSON. Useful for logging
+func (r *ClusterPolicyReport) GetSummaryJSON() (string, error) {
 	marshaled, err := json.Marshal(r.Summary)
 	if err != nil {
 		return "error marshalling summary", err

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -39,7 +39,7 @@ const (
 	SeverityInfo     = "info"
 
 	// Category specifies the category of a policy result
-	CategoryMutating   = "mutating & validating"
+	CategoryMutating   = "mutating"
 	CategoryValidating = "validating"
 
 	LabelAppManagedBy = "app.kubernetes.io/managed-by"

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -41,14 +41,20 @@ const (
 	// Category specifies the category of a policy result
 	CategoryMutating   = "mutating & validating"
 	CategoryValidating = "validating"
+
+	LabelAppManagedBy = "app.kubernetes.io/managed-by"
+	LabelApp          = "kubewarden"
 )
 
 func NewClusterPolicyReport(name string) ClusterPolicyReport {
+	labels := map[string]string{}
+	labels[LabelAppManagedBy] = LabelApp
 	return ClusterPolicyReport{
 		ClusterPolicyReport: v1alpha2.ClusterPolicyReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              PrefixNameClusterPolicyReport + name,
 				CreationTimestamp: metav1.Now(),
+				Labels:            labels,
 			},
 			Summary: v1alpha2.PolicyReportSummary{
 				Pass:  0, // count of policies with requirements met
@@ -63,12 +69,15 @@ func NewClusterPolicyReport(name string) ClusterPolicyReport {
 }
 
 func NewPolicyReport(namespace *v1.Namespace) PolicyReport {
+	labels := map[string]string{}
+	labels[LabelAppManagedBy] = LabelApp
 	return PolicyReport{
 		PolicyReport: v1alpha2.PolicyReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              PrefixNamePolicyReport + namespace.Name,
 				Namespace:         namespace.Name,
 				CreationTimestamp: metav1.Now(),
+				Labels:            labels,
 			},
 			Scope: &v1.ObjectReference{
 				Kind:            namespace.Kind,

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -120,7 +120,8 @@ func (r *PolicyReport) AddResult(policy policiesv1.Policy, resource unstructured
 		).Msg("added result to report")
 }
 
-func (r *PolicyReport) GetSummary() (string, error) {
+// GetSummaryJSON gets the report.Summary formatted in JSON. Useful for logging
+func (r *PolicyReport) GetSummaryJSON() (string, error) {
 	marshaled, err := json.Marshal(r.Summary)
 	if err != nil {
 		return "error marshalling summary", err

--- a/internal/report/store.go
+++ b/internal/report/store.go
@@ -200,7 +200,7 @@ func (s *PolicyReportStore) SavePolicyReport(report *PolicyReport) error {
 		if err != nil {
 			return fmt.Errorf("create failed: %w", err)
 		}
-		summary, _ := report.GetSummary()
+		summary, _ := report.GetSummaryJSON()
 		log.Info().
 			Dict("dict", zerolog.Dict().
 				Str("report name", report.Name).Str("report ns", report.Namespace).
@@ -233,7 +233,7 @@ func (s *PolicyReportStore) SavePolicyReport(report *PolicyReport) error {
 		if retryErr != nil {
 			return fmt.Errorf("update failed: %w", retryErr)
 		}
-		summary, _ := report.GetSummary()
+		summary, _ := report.GetSummaryJSON()
 		log.Info().
 			Dict("dict", zerolog.Dict().
 				Str("report name", report.Name).Str("report ns", report.Namespace).

--- a/internal/report/store.go
+++ b/internal/report/store.go
@@ -195,24 +195,23 @@ func (s *PolicyReportStore) SavePolicyReport(report *PolicyReport) error {
 		log.Debug().
 			Dict("dict", zerolog.Dict().
 				Str("report name", report.Name).Str("report ns", report.Namespace),
-			).
-			Msg("creating PolicyReport")
+			).Msg("creating PolicyReport")
 		err := s.client.Create(context.TODO(), &report.PolicyReport)
 		if err != nil {
 			return fmt.Errorf("create failed: %w", err)
 		}
+		summary, _ := report.GetSummary()
 		log.Info().
 			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace),
-			).
-			Msg("created PolicyReport")
+				Str("report name", report.Name).Str("report ns", report.Namespace).
+				Str("summary", summary),
+			).Msg("created PolicyReport")
 	} else {
 		// Update existing Policy Report
 		log.Debug().
 			Dict("dict", zerolog.Dict().
 				Str("report name", report.Name).Str("report ns", report.Namespace),
-			).
-			Msg("updating PolicyReport")
+			).Msg("updating PolicyReport")
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			getObj := &polReport.PolicyReport{}
 			err := s.client.Get(context.TODO(), types.NamespacedName{
@@ -234,11 +233,12 @@ func (s *PolicyReportStore) SavePolicyReport(report *PolicyReport) error {
 		if retryErr != nil {
 			return fmt.Errorf("update failed: %w", retryErr)
 		}
+		summary, _ := report.GetSummary()
 		log.Info().
 			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace),
-			).
-			Msg("updated PolicyReport")
+				Str("report name", report.Name).Str("report ns", report.Namespace).
+				Str("summary", summary),
+			).Msg("updated PolicyReport")
 	}
 	return nil
 }
@@ -256,10 +256,17 @@ func (s *PolicyReportStore) SaveClusterPolicyReport() error {
 		if err != nil {
 			return fmt.Errorf("create failed: %w", err)
 		}
-		log.Info().Msg("created ClusterPolicyReport")
+		summary, _ := report.GetSummary()
+		log.Info().
+			Dict("dict", zerolog.Dict().
+				Str("report name", report.Name).Str("report ns", report.Namespace).
+				Str("summary", summary),
+			).Msg("created ClusterPolicyReport")
 	} else {
 		// Update existing Policy Report
-		log.Debug().Msg("updating ClusterPolicyReport")
+		log.Debug().
+			Dict("dict", zerolog.Dict().Str("report name", report.Name)).
+			Msg("updating ClusterPolicyReport")
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			getObj := &polReport.ClusterPolicyReport{}
 			err := s.client.Get(context.TODO(), client.ObjectKey{Name: report.Name}, getObj)
@@ -278,9 +285,11 @@ func (s *PolicyReportStore) SaveClusterPolicyReport() error {
 		if retryErr != nil {
 			return fmt.Errorf("update failed: %w", retryErr)
 		}
+		summary, _ := report.GetSummary()
 		log.Info().
 			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name),
+				Str("report name", report.Name).Str("report ns", report.Namespace).
+				Str("summary", summary),
 			).Msg("updated ClusterPolicyReport")
 	}
 	return nil

--- a/internal/report/store.go
+++ b/internal/report/store.go
@@ -256,7 +256,7 @@ func (s *PolicyReportStore) SaveClusterPolicyReport() error {
 		if err != nil {
 			return fmt.Errorf("create failed: %w", err)
 		}
-		summary, _ := report.GetSummary()
+		summary, _ := report.GetSummaryJSON()
 		log.Info().
 			Dict("dict", zerolog.Dict().
 				Str("report name", report.Name).Str("report ns", report.Namespace).
@@ -285,7 +285,7 @@ func (s *PolicyReportStore) SaveClusterPolicyReport() error {
 		if retryErr != nil {
 			return fmt.Errorf("update failed: %w", retryErr)
 		}
-		summary, _ := report.GetSummary()
+		summary, _ := report.GetSummaryJSON()
 		log.Info().
 			Dict("dict", zerolog.Dict().
 				Str("report name", report.Name).Str("report ns", report.Namespace).

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -70,8 +70,7 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 	if err != nil {
 		return err
 	}
-	// log.Debug().Str("namespace", nsName).Int("count", len(policies)).Msg("number of policies to evaluate")
-	log.Debug().
+	log.Info().
 		Str("namespace", nsName).
 		Dict("dict", zerolog.Dict().
 			Int("policies to evaluate", len(policies)).


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/helm-charts/issues/237

- chore: Provide more info logs
- ci: Test container image on build
- feat: Add ManagedBy label
- Set PolicyReportResult fields:
  - severity: `"info"` if on monitor mode, empty otherwise
  - scored: `true` if severity set
  - rule: policy name
  - category: either `"validating"` or `"mutating & validating"`

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally out-of-cluster.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

~~ClusterPolicyReport doesn't show on policy-reporter.~~ it does.
