### PR TITLE
feat: reuse report results.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -7,6 +7,7 @@ const (
 	KubewardenPoliciesVersion            = "v1"
 	KubewardenKindClusterAdmissionPolicy = "ClusterAdmissionPolicy"
 	KubewardenKindAdmissionPolicy        = "AdmissionPolicy"
+	DefaultClusterwideReportName         = "clusterwide"
 )
 
 // ErrResourceNotFound is an error used to tell that the required resource is not found

--- a/internal/report/constants.go
+++ b/internal/report/constants.go
@@ -4,4 +4,6 @@ const (
 	PrefixNameClusterPolicyReport = "polr-"
 	PrefixNamePolicyReport        = "polr-ns-"
 	PolicyReportSource            = "kubewarden"
+	PropertyPolicyResourceVersion = "policy-resource-version"
+	PropertyPolicyUID             = "policy-uid"
 )

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -2,18 +2,23 @@ package report
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kubewarden/audit-scanner/internal/constants"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
 	admv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 
-func TestAddResult(t *testing.T) {
-	report := NewClusterPolicyReport("clusterwide")
+func TestCreateResult(t *testing.T) {
+	report := NewClusterPolicyReport("")
 	admReviewPass := admv1.AdmissionReview{
 		Request: &admv1.AdmissionRequest{},
 		Response: &admv1.AdmissionResponse{
@@ -38,16 +43,259 @@ func TestAddResult(t *testing.T) {
 		Kind:    constants.KubewardenKindClusterAdmissionPolicy,
 	})
 
-	report.AddResult(&policy, unstructured.Unstructured{}, &admReviewPass, nil)
+	report.AddResult(report.CreateResult(&policy, unstructured.Unstructured{}, &admReviewPass, nil))
 	if report.Summary.Pass != 1 {
-		t.Errorf("expected Summary.Pass == 1")
+		t.Errorf("expected Summary.Pass == 1. Got %d", report.Summary.Pass)
 	}
-	report.AddResult(&policy, unstructured.Unstructured{}, &admReviewFail, nil)
+	report.AddResult(report.CreateResult(&policy, unstructured.Unstructured{}, &admReviewFail, nil))
 	if report.Summary.Fail != 1 {
-		t.Errorf("expected Summary.Fail == 1")
+		t.Errorf("expected Summary.Fail == 1. Got %d", report.Summary.Fail)
 	}
-	report.AddResult(&policy, unstructured.Unstructured{}, &admReviewFail, errors.New("boom"))
+	report.AddResult(report.CreateResult(&policy, unstructured.Unstructured{}, &admReviewFail, errors.New("boom")))
 	if report.Summary.Error != 1 {
-		t.Errorf("expected Summary.Error == 1")
+		t.Errorf("expected Summary.Error == 1. Got %d", report.Summary.Error)
+	}
+}
+
+func TestFindClusterPolicyReportResult(t *testing.T) {
+	report := NewClusterPolicyReport("")
+	admReviewPass := admv1.AdmissionReview{
+		Request: &admv1.AdmissionRequest{},
+		Response: &admv1.AdmissionResponse{
+			UID:     "4264aa6a-2d4a-49e6-aed8-156d74678dde",
+			Allowed: true,
+		},
+	}
+	policy := policiesv1.ClusterAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-policy",
+		},
+		Spec: policiesv1.ClusterAdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{
+				BackgroundAudit: true,
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"namespaces"},
+					},
+				},
+				},
+			},
+		},
+	}
+	policy.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constants.KubewardenPoliciesGroup,
+		Version: constants.KubewardenPoliciesVersion,
+		Kind:    constants.KubewardenKindClusterAdmissionPolicy,
+	})
+
+	var expectedResource unstructured.Unstructured
+	for i := 0; i < 5; i++ {
+		namespaceResource := unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]interface{}{
+				"name":              "testingns" + fmt.Sprint(i),
+				"creationTimestamp": nil,
+			},
+			"spec":   map[string]interface{}{},
+			"status": map[string]interface{}{},
+		},
+		}
+		report.AddResult(report.CreateResult(&policy, namespaceResource, &admReviewPass, nil))
+		expectedResource = namespaceResource
+	}
+
+	result := report.GetReusablePolicyReportResult(&policy, expectedResource)
+	if result == nil {
+		t.Fatal("Result cannot be nil")
+	}
+	expectedPolicy := "cap-" + policy.GetName()
+	if result.Policy != expectedPolicy {
+		t.Errorf("Wrong policy. Expected %s, got %s", expectedPolicy, result.Policy)
+	}
+	expectedObjectReference := &v1.ObjectReference{
+		Kind:            expectedResource.GetKind(),
+		Namespace:       expectedResource.GetNamespace(),
+		Name:            expectedResource.GetName(),
+		UID:             expectedResource.GetUID(),
+		APIVersion:      expectedResource.GetAPIVersion(),
+		ResourceVersion: expectedResource.GetResourceVersion(),
+	}
+	if !cmp.Equal(result.Subjects[0], expectedObjectReference) {
+		diff := cmp.Diff(expectedObjectReference, result.Subjects[0])
+		t.Errorf("Result ObjectReference differs from the expected value: %s", diff)
+	}
+}
+
+func TestFindPolicyReportResult(t *testing.T) {
+	namespace := &v1.Namespace{}
+	report := NewPolicyReport(namespace)
+	admReviewPass := admv1.AdmissionReview{
+		Request: &admv1.AdmissionRequest{},
+		Response: &admv1.AdmissionResponse{
+			UID:     "4264aa6a-2d4a-49e6-aed8-156d74678dde",
+			Allowed: true,
+		},
+	}
+	policy := policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespace-policy",
+		},
+		Spec: policiesv1.AdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{
+				BackgroundAudit: true,
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				},
+				},
+			},
+		},
+	}
+	policy.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constants.KubewardenPoliciesGroup,
+		Version: constants.KubewardenPoliciesVersion,
+		Kind:    constants.KubewardenKindClusterAdmissionPolicy,
+	})
+
+	var expectedResource unstructured.Unstructured
+	for i := 0; i < 5; i++ {
+		namespaceResource := unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":              "testingns" + fmt.Sprint(i),
+				"creationTimestamp": nil,
+			},
+			"spec":   map[string]interface{}{},
+			"status": map[string]interface{}{},
+		},
+		}
+		report.AddResult(report.CreateResult(&policy, namespaceResource, &admReviewPass, nil))
+		expectedResource = namespaceResource
+	}
+
+	result := report.GetReusablePolicyReportResult(&policy, expectedResource)
+	if result == nil {
+		t.Fatal("Result cannot be nil")
+	}
+	expectedPolicy := "cap-" + policy.GetName()
+	if result.Policy != expectedPolicy {
+		t.Errorf("Wrong policy. Expected %s, got %s", expectedPolicy, result.Policy)
+	}
+	expectedObjectReference := &v1.ObjectReference{
+		Kind:            expectedResource.GetKind(),
+		Namespace:       expectedResource.GetNamespace(),
+		Name:            expectedResource.GetName(),
+		UID:             expectedResource.GetUID(),
+		APIVersion:      expectedResource.GetAPIVersion(),
+		ResourceVersion: expectedResource.GetResourceVersion(),
+	}
+	if !cmp.Equal(result.Subjects[0], expectedObjectReference) {
+		diff := cmp.Diff(expectedObjectReference, result.Subjects[0])
+		t.Errorf("Result ObjectReference differs from the expected value: %s", diff)
+	}
+}
+
+func TestAddPolicyReportResults(t *testing.T) {
+	time := metav1.Now()
+	timestamp := *time.ProtoTime()
+	tests := []struct {
+		name          string
+		result        *v1alpha2.PolicyReportResult
+		expectedPass  int
+		expectedFail  int
+		expectedError int
+	}{
+		{"pass", &v1alpha2.PolicyReportResult{
+			Source:   PolicyReportSource,
+			Policy:   "",           // either cap-policy_name or ap-policy_name
+			Rule:     "",           // policy name
+			Category: "validating", // either validating, or mutating and validating
+			Severity: "info",       // either info for monitor or empty
+			// Timestamp shouldn't be used in go structs, and only gives seconds
+			// https://github.com/kubernetes/apimachinery/blob/v0.27.2/pkg/apis/meta/v1/time_proto.go#LL48C9-L48C9
+			Timestamp:       timestamp,  // time the result was computed
+			Result:          StatusPass, // pass, fail, error
+			Scored:          false,
+			Subjects:        []*v1.ObjectReference{}, // reference to object evaluated
+			SubjectSelector: &metav1.LabelSelector{},
+			Description:     "", // output message of the policy
+			// The policy resource version is used to check if the same result can used
+			// in the next scan
+			Properties: map[string]string{PropertyPolicyResourceVersion: "", PropertyPolicyUID: ""},
+		}, 1, 0, 0},
+		{"fail", &v1alpha2.PolicyReportResult{
+			Source:   PolicyReportSource,
+			Policy:   "",           // either cap-policy_name or ap-policy_name
+			Rule:     "",           // policy name
+			Category: "validating", // either validating, or mutating and validating
+			Severity: "info",       // either info for monitor or empty
+			// Timestamp shouldn't be used in go structs, and only gives seconds
+			// https://github.com/kubernetes/apimachinery/blob/v0.27.2/pkg/apis/meta/v1/time_proto.go#LL48C9-L48C9
+			Timestamp:       timestamp,  // time the result was computed
+			Result:          StatusFail, // pass, fail, error
+			Scored:          false,
+			Subjects:        []*v1.ObjectReference{}, // reference to object evaluated
+			SubjectSelector: &metav1.LabelSelector{},
+			Description:     "", // output message of the policy
+			// The policy resource version is used to check if the same result can used
+			// in the next scan
+			Properties: map[string]string{PropertyPolicyResourceVersion: "", PropertyPolicyUID: ""},
+		}, 0, 1, 0},
+		{"error", &v1alpha2.PolicyReportResult{
+			Source:   PolicyReportSource,
+			Policy:   "",           // either cap-policy_name or ap-policy_name
+			Rule:     "",           // policy name
+			Category: "validating", // either validating, or mutating and validating
+			Severity: "info",       // either info for monitor or empty
+			// Timestamp shouldn't be used in go structs, and only gives seconds
+			// https://github.com/kubernetes/apimachinery/blob/v0.27.2/pkg/apis/meta/v1/time_proto.go#LL48C9-L48C9
+			Timestamp:       timestamp,   // time the result was computed
+			Result:          StatusError, // pass, fail, error
+			Scored:          false,
+			Subjects:        []*v1.ObjectReference{}, // reference to object evaluated
+			SubjectSelector: &metav1.LabelSelector{},
+			Description:     "", // output message of the policy
+			// The policy resource version is used to check if the same result can used
+			// in the next scan
+			Properties: map[string]string{PropertyPolicyResourceVersion: "", PropertyPolicyUID: ""},
+		}, 0, 0, 1},
+	}
+	for _, ttest := range tests {
+		t.Run(ttest.name, func(t *testing.T) {
+			clusterReport := NewClusterPolicyReport("")
+			namespace := &v1.Namespace{}
+			nsReport := NewPolicyReport(namespace)
+
+			clusterReport.AddResult(ttest.result)
+			nsReport.AddResult(ttest.result)
+
+			if clusterReport.Summary.Pass != ttest.expectedPass {
+				t.Errorf("Invalid cluster report summary. Expected pass evaluations count to be %d. But got %d", ttest.expectedPass, clusterReport.Summary.Pass)
+			}
+			if clusterReport.Summary.Fail != ttest.expectedFail {
+				t.Errorf("Invalid cluster report summary. Expected fail evaluations count to be %d. But got %d", ttest.expectedFail, clusterReport.Summary.Fail)
+			}
+			if clusterReport.Summary.Error != ttest.expectedError {
+				t.Errorf("Invalid cluster report summary. Expected error evaluations count to be %d. But got %d", ttest.expectedError, clusterReport.Summary.Error)
+			}
+			if nsReport.Summary.Pass != ttest.expectedPass {
+				t.Errorf("Invalid namespaced report summary. Expected pass evaluations count to be %d. But got %d", ttest.expectedPass, nsReport.Summary.Pass)
+			}
+			if nsReport.Summary.Fail != ttest.expectedFail {
+				t.Errorf("Invalid namespaced report summary. Expected fail evaluations count to be %d. But got %d", ttest.expectedFail, nsReport.Summary.Fail)
+			}
+			if nsReport.Summary.Error != ttest.expectedError {
+				t.Errorf("Invalid namespaced report summary. Expected error evaluations count to be %d. But got %d", ttest.expectedError, nsReport.Summary.Error)
+			}
+		})
 	}
 }

--- a/internal/report/store.go
+++ b/internal/report/store.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 
+	"strings"
+
+	"github.com/kubewarden/audit-scanner/internal/constants"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	errorMachinery "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
@@ -21,14 +25,7 @@ import (
 
 // PolicyReportStore caches the latest version of PolicyReports
 type PolicyReportStore struct {
-	// namespacedPolicyReports is a map of namespaces and namespaced PolicyReports
-	namespacedPolicyReports map[string]PolicyReport
-	// clusterPolicyReport is the sole ClusterPolicyReport
-	clusterPolicyReport ClusterPolicyReport
-
-	namespacedPolicyReportsMutex *sync.RWMutex
-	clusterPolicyReportMutex     *sync.RWMutex
-
+	// For now, the store has K8s/etcd backend only
 	// client used to instantiate PolicyReport resources
 	client client.Client
 }
@@ -51,246 +48,244 @@ func NewPolicyReportStore() (*PolicyReportStore, error) {
 		return nil, fmt.Errorf("failed when creating new client: %w", err)
 	}
 
-	return &PolicyReportStore{
-		namespacedPolicyReports:      make(map[string]PolicyReport),
-		clusterPolicyReport:          NewClusterPolicyReport("clusterwide"),
-		namespacedPolicyReportsMutex: new(sync.RWMutex),
-		clusterPolicyReportMutex:     new(sync.RWMutex),
-		client:                       client,
-	}, nil
+	return &PolicyReportStore{client: client}, nil
 }
 
 // MockNewPolicyReportStore constructs a PolicyReportStore, initializing the
 // clusterwide ClusterPolicyReport and namespacedPolicyReports, but setting the
 // client. Useful for testing.
 func MockNewPolicyReportStore(client client.Client) *PolicyReportStore {
-	return &PolicyReportStore{
-		namespacedPolicyReports:      make(map[string]PolicyReport),
-		clusterPolicyReport:          NewClusterPolicyReport("clusterwide"),
-		namespacedPolicyReportsMutex: new(sync.RWMutex),
-		clusterPolicyReportMutex:     new(sync.RWMutex),
-		client:                       client,
-	}
+	return &PolicyReportStore{client: client}
 }
 
-// AddPolicyReport adds a namespaced PolicyReport to the Store
-func (s *PolicyReportStore) AddPolicyReport(report *PolicyReport) error {
-	s.namespacedPolicyReportsMutex.Lock()
-	defer s.namespacedPolicyReportsMutex.Unlock()
-	s.namespacedPolicyReports[report.GetNamespace()] = *report
-	return nil
-}
-
-// AddClusterPolicyReport adds the ClusterPolicyReport to the Store
-func (s *PolicyReportStore) AddClusterPolicyReport(report *ClusterPolicyReport) error {
-	s.clusterPolicyReportMutex.Lock()
-	defer s.clusterPolicyReportMutex.Unlock()
-	s.clusterPolicyReport = *report
-	return nil
-}
-
-// Get PolicyReport by namespace
+// GetPolicyReport returns the Policy Report defined inside of the
+// given namespace.
+// An empty PolicyReport is returned when nothing is found
 func (s *PolicyReportStore) GetPolicyReport(namespace string) (PolicyReport, error) {
-	s.namespacedPolicyReportsMutex.RLock()
-	defer s.namespacedPolicyReportsMutex.RUnlock()
-	report, present := s.namespacedPolicyReports[namespace]
-	if present {
-		return report, nil
+	report := polReport.PolicyReport{}
+	getErr := s.client.Get(context.TODO(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      getNamespacedReportName(namespace),
+	}, &report)
+	if getErr != nil {
+		if errorMachinery.IsNotFound(getErr) {
+			return PolicyReport{}, constants.ErrResourceNotFound
+		}
+		return PolicyReport{}, getErr
 	}
-	return PolicyReport{}, errors.New("report not found")
+	policyReport := &PolicyReport{
+		report,
+	}
+	log.Debug().Dict("dict", zerolog.Dict().
+		Str("report name", report.GetName()).
+		Str("report ns", report.GetNamespace()).
+		Str("report resourceVersion", report.GetResourceVersion())).
+		Msg("PolicyReport found")
+	return *policyReport, nil
 }
 
 // Get the ClusterPolicyReport
-func (s *PolicyReportStore) GetClusterPolicyReport() (ClusterPolicyReport, error) {
-	s.clusterPolicyReportMutex.RLock()
-	defer s.clusterPolicyReportMutex.RUnlock()
-	report := s.clusterPolicyReport
-	return report, nil
+func (s *PolicyReportStore) GetClusterPolicyReport(name string) (ClusterPolicyReport, error) {
+	result := polReport.ClusterPolicyReport{}
+	if !strings.HasPrefix(name, PrefixNameClusterPolicyReport) {
+		name = getClusterReportName(name)
+	}
+	getErr := s.client.Get(context.Background(), client.ObjectKey{Name: name}, &result)
+	if getErr != nil {
+		if errorMachinery.IsNotFound(getErr) {
+			return ClusterPolicyReport{}, constants.ErrResourceNotFound
+		}
+		return ClusterPolicyReport{}, getErr
+	}
+	return ClusterPolicyReport{
+		result,
+	}, nil
 }
 
 // Update namespaced PolicyReport
 func (s *PolicyReportStore) UpdatePolicyReport(report *PolicyReport) error {
-	s.namespacedPolicyReportsMutex.Lock()
-	defer s.namespacedPolicyReportsMutex.Unlock()
-	s.namespacedPolicyReports[report.GetNamespace()] = *report
+	err := s.client.Update(context.Background(), &report.PolicyReport)
+	if err != nil {
+		return err
+	}
+	summary, _ := report.GetSummaryJSON()
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Str("report name", report.GetName()).
+			Str("report ns", report.GetNamespace()).
+			Str("report resourceVersion", report.GetResourceVersion()).
+			Str("summary", summary),
+		).Msg("updated PolicyReport")
 	return nil
 }
 
 // Update ClusterPolicyReport or PolicyReport. ns argument is used in case
 // of namespaced PolicyReport
 func (s *PolicyReportStore) UpdateClusterPolicyReport(report *ClusterPolicyReport) error {
-	s.clusterPolicyReportMutex.Lock()
-	defer s.clusterPolicyReportMutex.Unlock()
-	s.clusterPolicyReport = *report
+	err := s.client.Update(context.Background(), &report.ClusterPolicyReport)
+	if err != nil {
+		return err
+	}
+	summary, _ := report.GetSummaryJSON()
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Str("report name", report.GetName()).
+			Str("report ns", report.GetNamespace()).
+			Str("summary", summary),
+		).Msg("updated ClusterPolicyReport")
 	return nil
 }
 
 // Delete PolicyReport by namespace
 func (s *PolicyReportStore) RemovePolicyReport(namespace string) error {
-	if _, err := s.GetPolicyReport(namespace); err == nil {
-		s.namespacedPolicyReportsMutex.Lock()
-		defer s.namespacedPolicyReportsMutex.Unlock()
-		delete(s.namespacedPolicyReports, namespace)
+	if report, err := s.GetPolicyReport(namespace); err == nil {
+		err := s.client.Delete(context.Background(), &report.PolicyReport)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 // Delete all namespaced PolicyReports
 func (s *PolicyReportStore) RemoveAllNamespacedPolicyReports() error {
-	s.namespacedPolicyReportsMutex.Lock()
-	defer s.namespacedPolicyReportsMutex.Unlock()
-	// TODO once go 1.21 is out, use new `clear` builtin
-	s.namespacedPolicyReports = make(map[string]PolicyReport)
+	err := s.client.DeleteAllOf(context.Background(), &polReport.PolicyReport{},
+		client.MatchingLabels(map[string]string{
+			LabelAppManagedBy: LabelApp,
+		}))
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
-// Marshal the contents of the store into a JSON string
-func (s *PolicyReportStore) ToJSON() (string, error) {
-	recapJSON := make(map[string]interface{})
-	recapJSON["cluster"] = s.clusterPolicyReport
-	recapJSON["namespaces"] = s.namespacedPolicyReports
-
-	marshaled, err := json.Marshal(recapJSON)
+// createPolicyReport should not be called directly. Use the SavePolicyReport
+func (s *PolicyReportStore) createPolicyReport(report *PolicyReport) error {
+	err := s.client.Create(context.Background(), &report.PolicyReport)
 	if err != nil {
-		return "", err
+		return fmt.Errorf("create failed: %w", err)
 	}
-	return string(marshaled), nil
+	summary, _ := report.GetSummaryJSON()
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Str("report name", report.GetName()).
+			Str("report ns", report.GetNamespace()).
+			Str("summary", summary),
+		).Msg("created PolicyReport")
+	return nil
 }
 
-// SaveAll saves the store policy reports to the cluster. It does this by
-// instantiating new clusterPolicyReport and PolicyReports, or updating them if
-// they are already present.
-func (s *PolicyReportStore) SaveAll() error {
-	var errs error
-	if err := s.SaveClusterPolicyReport(); err != nil {
-		log.Error().Err(err).
-			Str("report name", s.clusterPolicyReport.GetName()).
-			Msg("error saving ClusterPolicyReport")
-		errs = errors.New(errs.Error() + err.Error())
+// createClusterPolicyReport should not be called directly. Use the SaveClusterPolicyReport
+func (s *PolicyReportStore) createClusterPolicyReport(report *ClusterPolicyReport) error {
+	err := s.client.Create(context.Background(), &report.ClusterPolicyReport)
+	if err != nil {
+		return fmt.Errorf("create failed: %w", err)
 	}
-
-	for _, report := range s.namespacedPolicyReports {
-		report := report
-		if err := s.SavePolicyReport(&report); err != nil {
-			log.Error().Err(err).
-				Str("report name", report.GetName()).
-				Msg("error saving PolicyReport")
-			errs = errors.New(errs.Error() + err.Error())
-		}
-	}
-	return errs
+	summary, _ := report.GetSummaryJSON()
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Str("report name", report.GetName()).
+			Str("report ns", report.GetNamespace()).
+			Str("summary", summary),
+		).Msg("created ClusterPolicyReport")
+	return nil
 }
 
 // SavePolicyReport instantiates the passed namespaced PolicyReport if it doesn't exist, or
 // updates it if one is found
 func (s *PolicyReportStore) SavePolicyReport(report *PolicyReport) error {
 	// Check for existing Policy Report
-	result := &polReport.PolicyReport{}
-	getErr := s.client.Get(context.TODO(), types.NamespacedName{
-		Namespace: report.Namespace,
-		Name:      report.Name,
-	}, result)
-	// Create new Policy Report if not found
-	if errorMachinery.IsNotFound(getErr) {
-		log.Debug().
-			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace),
-			).Msg("creating PolicyReport")
-		err := s.client.Create(context.TODO(), &report.PolicyReport)
+	_, getErr := s.GetPolicyReport(report.GetNamespace())
+	if getErr != nil {
+		// Create new Policy Report if not found
+		if errors.Is(getErr, constants.ErrResourceNotFound) {
+			return s.createPolicyReport(report)
+		}
+		return getErr
+	}
+	// Update existing Policy Report
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// get the latest report version to be updated
+		latestReport, err := s.GetPolicyReport(report.GetNamespace())
 		if err != nil {
-			return fmt.Errorf("create failed: %w", err)
+			return err
 		}
-		summary, _ := report.GetSummaryJSON()
-		log.Info().
-			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace).
-				Str("summary", summary),
-			).Msg("created PolicyReport")
-	} else {
-		// Update existing Policy Report
-		log.Debug().
-			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace),
-			).Msg("updating PolicyReport")
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			getObj := &polReport.PolicyReport{}
-			err := s.client.Get(context.TODO(), types.NamespacedName{
-				Namespace: report.Namespace,
-				Name:      report.Name,
-			}, getObj)
-			if errorMachinery.IsNotFound(err) {
-				// This should never happen
-				return fmt.Errorf("not found when updating: %w", err)
-			}
-			if err != nil {
-				return fmt.Errorf("get failed when updating: %w", err)
-			}
-			report.SetResourceVersion(getObj.GetResourceVersion())
-			updateErr := s.client.Update(context.TODO(), &report.PolicyReport)
-			// return unwrapped error for RetryOnConflict()
-			return updateErr
-		})
-		if retryErr != nil {
-			return fmt.Errorf("update failed: %w", retryErr)
-		}
-		summary, _ := report.GetSummaryJSON()
-		log.Info().
-			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace).
-				Str("summary", summary),
-			).Msg("updated PolicyReport")
+		latestReport.Summary = report.Summary
+		latestReport.Results = report.Results
+		return s.UpdatePolicyReport(&latestReport)
+	})
+	if retryErr != nil {
+		return fmt.Errorf("update failed: %w", retryErr)
 	}
 	return nil
 }
 
 // SavePolicyClusterPolicyReport instantiates the ClusterPolicyReport if it doesn't exist, or
 // updates it one is found
-func (s *PolicyReportStore) SaveClusterPolicyReport() error {
+func (s *PolicyReportStore) SaveClusterPolicyReport(report *ClusterPolicyReport) error {
 	// Check for existing Policy Report
-	report := s.clusterPolicyReport
-	result := &polReport.ClusterPolicyReport{}
-	getErr := s.client.Get(context.TODO(), client.ObjectKey{Name: report.Name}, result)
-	// Create new Policy Report if not found
-	if errorMachinery.IsNotFound(getErr) {
-		err := s.client.Create(context.TODO(), &report.ClusterPolicyReport)
+	_, getErr := s.GetClusterPolicyReport(report.GetName())
+	if getErr != nil {
+		// Create new Policy Report if not found
+		if errors.Is(getErr, constants.ErrResourceNotFound) {
+			return s.createClusterPolicyReport(report)
+		}
+		return getErr
+	}
+	// Update existing Policy Report
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// get the latest report version to be updated
+		latestReport, err := s.GetClusterPolicyReport(report.GetName())
 		if err != nil {
-			return fmt.Errorf("create failed: %w", err)
+			return err
 		}
-		summary, _ := report.GetSummaryJSON()
-		log.Info().
-			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace).
-				Str("summary", summary),
-			).Msg("created ClusterPolicyReport")
-	} else {
-		// Update existing Policy Report
-		log.Debug().
-			Dict("dict", zerolog.Dict().Str("report name", report.Name)).
-			Msg("updating ClusterPolicyReport")
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			getObj := &polReport.ClusterPolicyReport{}
-			err := s.client.Get(context.TODO(), client.ObjectKey{Name: report.Name}, getObj)
-			if errorMachinery.IsNotFound(err) {
-				// This should never happen
-				return fmt.Errorf("not found when updating: %w", err)
-			}
-			if err != nil {
-				return fmt.Errorf("get failed when updating: %w", err)
-			}
-			report.SetResourceVersion(getObj.GetResourceVersion())
-			updateErr := s.client.Update(context.TODO(), &report.ClusterPolicyReport)
-			// return unwrapped error for RetryOnConflict()
-			return updateErr
-		})
-		if retryErr != nil {
-			return fmt.Errorf("update failed: %w", retryErr)
-		}
-		summary, _ := report.GetSummaryJSON()
-		log.Info().
-			Dict("dict", zerolog.Dict().
-				Str("report name", report.Name).Str("report ns", report.Namespace).
-				Str("summary", summary),
-			).Msg("updated ClusterPolicyReport")
+		latestReport.Summary = report.Summary
+		latestReport.Results = report.Results
+		return s.UpdateClusterPolicyReport(&latestReport)
+	})
+	if retryErr != nil {
+		return fmt.Errorf("update failed: %w", retryErr)
 	}
 	return nil
+}
+
+// listPolicyReports returns all the Policy Reports
+// An empty PolicyReport list is returned when nothing is found or an error happens
+func (s *PolicyReportStore) listPolicyReports() ([]PolicyReport, error) {
+	reportList := polReport.PolicyReportList{}
+	err := s.client.List(context.Background(), &reportList, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{LabelAppManagedBy: LabelApp}),
+	})
+	if err != nil {
+		if errorMachinery.IsNotFound(err) {
+			return []PolicyReport{}, constants.ErrResourceNotFound
+		}
+		return []PolicyReport{}, err
+	}
+	results := make([]PolicyReport, 0, len(reportList.Items))
+	for _, item := range reportList.Items {
+		results = append(results, PolicyReport{item})
+	}
+	return results, nil
+}
+
+// Marshal the contents of the store into a JSON string
+func (s *PolicyReportStore) ToJSON() (string, error) {
+	recapJSON := make(map[string]interface{})
+	clusterReport, err := s.GetClusterPolicyReport(constants.DefaultClusterwideReportName)
+	if err != nil {
+		log.Error().Err(err).Msg("error fetching ClusterPolicyReport. Ignoring this error to allow user to read the namespaced reports")
+	}
+	recapJSON["cluster"] = clusterReport
+	nsReports, err := s.listPolicyReports()
+	if err != nil {
+		return "", err
+	}
+	recapJSON["namespaces"] = nsReports
+
+	marshaled, err := json.Marshal(recapJSON)
+	if err != nil {
+		return "", err
+	}
+	return string(marshaled), nil
 }

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,43 +1,54 @@
 package scanner
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/kubewarden/audit-scanner/internal/constants"
+	"github.com/kubewarden/audit-scanner/internal/report"
+	"github.com/kubewarden/audit-scanner/internal/resources"
+	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
 	admv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-const auditURL = "http://localhost:9876/audit/"
-
-func startServer() {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/audit/", func(response http.ResponseWriter, req *http.Request) {
-		_, err := io.Copy(response, req.Body)
-		if err != nil {
-			fmt.Fprintf(response, "Cannot write the response")
-		}
-	})
-	mux.HandleFunc("/", func(response http.ResponseWriter, req *http.Request) {
-		// The "/" pattern matches everything, so we need to check
-		// that we're at the root here.
-		if req.URL.Path != "/" {
-			http.NotFound(response, req)
-			return
-		}
-		fmt.Fprintf(response, "Welcome to the home page!")
-	})
-	err := http.ListenAndServe("localhost:9876", mux) //nolint
+var defaultHTTPTestingServerFunc = func(response http.ResponseWriter, req *http.Request) {
+	_, err := io.Copy(response, req.Body)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(response, "Cannot write the response")
 	}
 }
 
+var defaultHTTPTestingServerHandler = http.HandlerFunc(defaultHTTPTestingServerFunc)
+
+type ResourcesFetcherMock struct {
+	auditURL string
+}
+
+func (r ResourcesFetcherMock) GetResourcesForPolicies(_ context.Context, _ []policiesv1.Policy, _ string) ([]resources.AuditableResources, error) {
+	return []resources.AuditableResources{}, nil
+}
+
+func (r ResourcesFetcherMock) GetPolicyServerURLRunningPolicy(_ context.Context, _ policiesv1.Policy) (*url.URL, error) {
+	return url.Parse(r.auditURL)
+}
+
+func (r ResourcesFetcherMock) GetClusterWideResourcesForPolicies(_ context.Context, _ []policiesv1.Policy) ([]resources.AuditableResources, error) {
+	return []resources.AuditableResources{}, nil
+}
+
 func TestSendRequestToPolicyServer(t *testing.T) {
-	go startServer()
+	server := httptest.NewServer(defaultHTTPTestingServerHandler)
+	defer func() { server.Close() }()
 
 	admRequest := admv1.AdmissionRequest{
 		UID:  "uid",
@@ -59,11 +70,11 @@ func TestSendRequestToPolicyServer(t *testing.T) {
 		Request:  &admRequest,
 		Response: nil,
 	}
-	url, err := url.Parse(auditURL)
+	url, err := url.Parse(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	response, err := sendAdmissionReviewToPolicyServer(url, &admReview, &http.Client{})
+	response, err := sendAdmissionReviewToPolicyServer(url, &admReview, server.Client())
 	if err != nil && response == nil {
 		t.Fatal(err)
 	}
@@ -77,5 +88,134 @@ func TestSendRequestToPolicyServer(t *testing.T) {
 	}
 	if admissionRequest.Kind.Version != "v1" {
 		t.Errorf("Version diverge")
+	}
+}
+
+func TestEvaluationClusterReportCache(t *testing.T) {
+	serverCalled := false
+	admReview := admv1.AdmissionReview{
+		Request: &admv1.AdmissionRequest{},
+		Response: &admv1.AdmissionResponse{
+			Allowed: true,
+			UID:     "asdf-rwegc-qwasd-hwertreg",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, req *http.Request) {
+		serverCalled = true
+		payload, _ := json.Marshal(admReview)
+		_, err := response.Write(payload)
+		if err != nil {
+			panic("Unexpected error on testing HTTP server!")
+		}
+	}))
+	defer func() { server.Close() }()
+
+	policy := policiesv1.ClusterAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-admission-policy",
+		},
+	}
+	policy.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constants.KubewardenPoliciesGroup,
+		Version: constants.KubewardenPoliciesVersion,
+		Kind:    constants.KubewardenKindClusterAdmissionPolicy,
+	})
+	policy.SetResourceVersion("1")
+	resource := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name":            "testingns",
+			"resourceVersion": "2",
+		},
+		"spec":   map[string]interface{}{},
+		"status": map[string]interface{}{},
+	},
+	}
+
+	auditableResource := resources.AuditableResources{
+		Policies: []policiesv1.Policy{&policy},
+		// It can be any kubernetes resource
+		Resources: []unstructured.Unstructured{resource},
+	}
+
+	resourcesFetcher := ResourcesFetcherMock{
+		auditURL: server.URL,
+	}
+	clusterReport := report.NewClusterPolicyReport("")
+	previousClusterReport := report.NewClusterPolicyReport("")
+	previousClusterReport.AddResult(previousClusterReport.CreateResult(&policy, resource, &admReview, nil))
+
+	auditClusterResource(&auditableResource, resourcesFetcher, server.Client(), &clusterReport, &previousClusterReport)
+
+	if serverCalled {
+		t.Errorf("Policy server should not be contacted")
+	}
+}
+
+func TestEvaluationNamespaceReportCache(t *testing.T) {
+	serverCalled := false
+	admReview := admv1.AdmissionReview{
+		Request: &admv1.AdmissionRequest{},
+		Response: &admv1.AdmissionResponse{
+			Allowed: true,
+			UID:     "asdf-rwegc-qwasd-hwertreg",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, req *http.Request) {
+		serverCalled = true
+		payload, _ := json.Marshal(admReview)
+		_, err := response.Write(payload)
+		if err != nil {
+			panic("Unexpected error on testing HTTP server!")
+		}
+	}))
+	defer func() { server.Close() }()
+
+	policy := policiesv1.AdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "admission-policy",
+		},
+	}
+	policy.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constants.KubewardenPoliciesGroup,
+		Version: constants.KubewardenPoliciesVersion,
+		Kind:    constants.KubewardenKindAdmissionPolicy,
+	})
+	policy.SetResourceVersion("1")
+	resource := unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":            "testingpod",
+			"resourceVersion": "2",
+		},
+		"spec":   map[string]interface{}{},
+		"status": map[string]interface{}{},
+	},
+	}
+
+	auditableResource := resources.AuditableResources{
+		Policies: []policiesv1.Policy{&policy},
+		// It can be any kubernetes resource
+		Resources: []unstructured.Unstructured{resource},
+	}
+
+	resourcesFetcher := ResourcesFetcherMock{
+		auditURL: server.URL,
+	}
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mynamespace",
+		},
+	}
+	previousReport := report.NewPolicyReport(namespace)
+	previousReport.AddResult(previousReport.CreateResult(&policy, resource, &admReview, nil))
+	report := report.NewPolicyReport(namespace)
+
+	auditResource(&auditableResource, resourcesFetcher, server.Client(), &report, &previousReport)
+
+	if serverCalled {
+		t.Errorf("Policy server should not be contacted")
 	}
 }


### PR DESCRIPTION
## Description

The audit scanner now check if there is a policy evaluation result in the previous scan report for the same policy and resource version tuple. If there is, the result is copy into the new report.

Fix #44 

