### PR TITLE
feat: Scan all namespaces and cluster by default

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,32 +84,25 @@ func Execute() {
 	}
 }
 func startScanner(namespace string, clusterWide bool, scanner Scanner) error {
-	switch clusterWide {
-	case true:
-		if namespace != "" {
-			log.Fatal().Msg("Cannot scan cluster wide and only a namespace at the same time")
-		} else {
-			if err := scanner.ScanClusterWideResources(); err != nil {
-				return err
-			}
-		}
-	case false:
-		if namespace != "" {
-			if err := scanner.ScanNamespace(namespace); err != nil {
-				return err
-			}
-		} else {
-			// neither clusterWide flag nor namespace was provided, default
-			// behaviour of scanning cluster wide and all ns
-			if err := scanner.ScanClusterWideResources(); err != nil {
-				return err
-			}
-			if err := scanner.ScanAllNamespaces(); err != nil {
-				return err
-			}
-		}
+	if clusterWide && namespace != "" {
+		log.Fatal().Msg("Cannot scan cluster wide and only a namespace at the same time")
 	}
-	return nil
+
+	if clusterWide {
+		// only scan clusterwide
+		return scanner.ScanClusterWideResources()
+	}
+	if namespace != "" {
+		// only scan namespace
+		return scanner.ScanNamespace(namespace)
+	}
+
+	// neither clusterWide flag nor namespace was provided, default
+	// behaviour of scanning cluster wide and all ns
+	if err := scanner.ScanClusterWideResources(); err != nil {
+		return err
+	}
+	return scanner.ScanAllNamespaces()
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,5 +123,5 @@ func init() {
 	rootCmd.Flags().StringP("policy-server-url", "u", "", "Full URL to the PolicyServers, for example https://localhost:3000. Audit scanner will query the needed HTTP path. Useful for out-of-cluster debugging")
 	rootCmd.Flags().VarP(&level, "loglevel", "l", fmt.Sprintf("level of the logs. Supported values are: %v", logconfig.SupportedValues))
 	rootCmd.Flags().BoolVarP(&printJSON, "print", "p", false, "print result of scan in JSON to stdout")
-	rootCmd.Flags().StringP("skipped-ns", "s", "", "Comma separated list of namespace names to be skipped from scan")
+	rootCmd.Flags().StringP("ignore-namespaces", "i", "", "Comma separated list of namespace names to be skipped from scan")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,24 +81,31 @@ func Execute() {
 	}
 }
 func startScanner(namespace string, clusterWide bool, scanner Scanner) error {
-	if clusterWide {
-		if err := scanner.ScanClusterWideResources(); err != nil {
-			return err
+	switch clusterWide {
+	case true:
+		if namespace != "" {
+			log.Fatal().Msg("Cannot scan cluster wide and only a namespace at the same time")
+		} else {
+			if err := scanner.ScanClusterWideResources(); err != nil {
+				return err
+			}
+		}
+	case false:
+		if namespace != "" {
+			if err := scanner.ScanNamespace(namespace); err != nil {
+				return err
+			}
+		} else {
+			// neither clusterWide flag nor namespace was provided, default
+			// behaviour of scanning cluster wide and all ns
+			if err := scanner.ScanClusterWideResources(); err != nil {
+				return err
+			}
+			if err := scanner.ScanAllNamespaces(); err != nil {
+				return err
+			}
 		}
 	}
-
-	if namespace != "" {
-		if err := scanner.ScanNamespace(namespace); err != nil {
-			return err
-		}
-	} else if !clusterWide {
-		// FIXME ScanAllNamespaces is not implemented. Therefore, if we are
-		// scanning cluster wide resource do not trigger this scan. It will failed anyway
-		if err := scanner.ScanAllNamespaces(); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	logconfig "github.com/kubewarden/audit-scanner/internal/log"
 	"github.com/kubewarden/audit-scanner/internal/policies"
@@ -55,7 +56,13 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 			if err != nil {
 				return err
 			}
-			policiesFetcher, err := policies.NewFetcher(kubewardenNamespace)
+			skippedNsCSV, err := cmd.Flags().GetString("skipped-ns")
+			if err != nil {
+				return err
+			}
+			skippedNs := strings.Split(skippedNsCSV, ",")
+
+			policiesFetcher, err := policies.NewFetcher(kubewardenNamespace, skippedNs)
 			if err != nil {
 				return err
 			}
@@ -116,4 +123,5 @@ func init() {
 	rootCmd.Flags().StringP("policy-server-url", "u", "", "Full URL to the PolicyServers, for example https://localhost:3000. Audit scanner will query the needed HTTP path. Useful for out-of-cluster debugging")
 	rootCmd.Flags().VarP(&level, "loglevel", "l", fmt.Sprintf("level of the logs. Supported values are: %v", logconfig.SupportedValues))
 	rootCmd.Flags().BoolVarP(&printJSON, "print", "p", false, "print result of scan in JSON to stdout")
+	rootCmd.Flags().StringP("skipped-ns", "s", "", "Comma separated list of namespace names to be skipped from scan")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	logconfig "github.com/kubewarden/audit-scanner/internal/log"
 	"github.com/kubewarden/audit-scanner/internal/policies"
@@ -28,6 +27,9 @@ var level logconfig.Level
 
 // print result of scan as JSON to stdout
 var printJSON bool
+
+// list of namespaces to be skipped from scan
+var skippedNs []string
 
 // rootCmd represents the base command when called without any subcommands
 var (
@@ -56,12 +58,6 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 			if err != nil {
 				return err
 			}
-			skippedNsCSV, err := cmd.Flags().GetString("skipped-ns")
-			if err != nil {
-				return err
-			}
-			skippedNs := strings.Split(skippedNsCSV, ",")
-
 			policiesFetcher, err := policies.NewFetcher(kubewardenNamespace, skippedNs)
 			if err != nil {
 				return err
@@ -123,5 +119,5 @@ func init() {
 	rootCmd.Flags().StringP("policy-server-url", "u", "", "Full URL to the PolicyServers, for example https://localhost:3000. Audit scanner will query the needed HTTP path. Useful for out-of-cluster debugging")
 	rootCmd.Flags().VarP(&level, "loglevel", "l", fmt.Sprintf("level of the logs. Supported values are: %v", logconfig.SupportedValues))
 	rootCmd.Flags().BoolVarP(&printJSON, "print", "p", false, "print result of scan in JSON to stdout")
-	rootCmd.Flags().StringP("ignore-namespaces", "i", "", "Comma separated list of namespace names to be skipped from scan")
+	rootCmd.Flags().StringSliceVarP(&skippedNs, "ignore-namespaces", "i", nil, "Comma separated list of namespace names to be skipped from scan")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,16 +19,16 @@ func TestStartScannerForANamespace(t *testing.T) {
 	if mockScanner.scanAllNamespacesCalled == true {
 		t.Errorf("scanAllNamespaces should have not been called")
 	}
-	if mockScanner.scanClusterResources == true {
+	if mockScanner.scanClusterResourcesCalled == true {
 		t.Errorf("ScanClusterWideResources should have not been called")
 	}
 }
 
 func TestStartScannerForAllNamespaces(t *testing.T) {
-	const namespace = ""
 	mockScanner := mockScanner{}
 
-	err := startScanner(namespace, false, &mockScanner)
+	// analogous to passing no flags
+	err := startScanner("", false, &mockScanner)
 
 	if err != nil {
 		t.Errorf("err should be nil, but got %s", err.Error())
@@ -39,8 +39,8 @@ func TestStartScannerForAllNamespaces(t *testing.T) {
 	if mockScanner.scanAllNamespacesCalled != true {
 		t.Errorf("scanAllNamespaces not called")
 	}
-	if mockScanner.scanClusterResources == true {
-		t.Errorf("ScanClusterWideResources should have not been called")
+	if mockScanner.scanClusterResourcesCalled != true {
+		t.Errorf("scanClusterWideResources not called")
 	}
 }
 
@@ -59,15 +59,15 @@ func TestScanClusterResources(t *testing.T) {
 		t.Errorf("scanAllNamespaces should have not been called")
 	}
 
-	if mockScanner.scanClusterResources == false {
+	if mockScanner.scanClusterResourcesCalled == false {
 		t.Errorf("ScanClusterWideResources not called")
 	}
 }
 
 type mockScanner struct {
-	scanNamespaceCalledWith string
-	scanAllNamespacesCalled bool
-	scanClusterResources    bool
+	scanNamespaceCalledWith    string
+	scanAllNamespacesCalled    bool
+	scanClusterResourcesCalled bool
 }
 
 func (s *mockScanner) ScanNamespace(namespace string) error {
@@ -81,6 +81,6 @@ func (s *mockScanner) ScanAllNamespaces() error {
 }
 
 func (s *mockScanner) ScanClusterWideResources() error {
-	s.scanClusterResources = true
+	s.scanClusterResourcesCalled = true
 	return nil
 }

--- a/internal/policies/fetcher.go
+++ b/internal/policies/fetcher.go
@@ -25,7 +25,7 @@ type Fetcher struct {
 	// Namespace where the Kubewarden components (e.g. policy server) are installed
 	// This is the namespace used to fetch the policy server resources
 	kubewardenNamespace string
-	// list of skipped namespaces from audit, by name
+	// list of skipped namespaces from audit, by name. It includes kubewardenNamespace
 	skippedNs []string
 	// filter cribes the passed policies and returns only those that should be audited
 	filter func(policies []policiesv1.Policy) []policiesv1.Policy
@@ -39,6 +39,7 @@ func NewFetcher(kubewardenNamespace string, skippedNs []string) (*Fetcher, error
 	if err != nil {
 		return nil, err
 	}
+	skippedNs = append(skippedNs, kubewardenNamespace)
 	return &Fetcher{client: client, kubewardenNamespace: kubewardenNamespace, skippedNs: skippedNs, filter: filterAuditablePolicies}, nil
 }
 

--- a/internal/policies/fetcher.go
+++ b/internal/policies/fetcher.go
@@ -2,7 +2,6 @@ package policies
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/kubewarden/audit-scanner/internal/constants"
@@ -41,13 +40,6 @@ func NewFetcher(kubewardenNamespace string, skippedNs []string) (*Fetcher, error
 		return nil, err
 	}
 	return &Fetcher{client: client, kubewardenNamespace: kubewardenNamespace, skippedNs: skippedNs, filter: filterAuditablePolicies}, nil
-}
-
-// GetPoliciesForAllNamespace gets all auditable policies, and the number of
-// skipped policies
-// TODO implement this in the future
-func (f *Fetcher) GetPoliciesForAllNamespaces() ([]policiesv1.Policy, int, error) {
-	return nil, 0, errors.New("scanning all namespaces is not implemented yet. Please pass the --namespace flag to scan a namespace")
 }
 
 // GetPoliciesForANamespace gets all auditable policies for a given namespace, and the number

--- a/internal/resources/fetcher.go
+++ b/internal/resources/fetcher.go
@@ -25,6 +25,7 @@ const policyServerResource = "policyservers"
 // Fetcher fetches all auditable resources.
 // Uses a dynamic client to get all resources from the rules defined in a policy
 type Fetcher struct {
+	// dynamicClient is used to fetch resource data
 	dynamicClient dynamic.Interface
 	// Namespace where the Kubewarden components (e.g. policy server) are installed
 	// This is the namespace used to fetch the policy server resources
@@ -32,10 +33,8 @@ type Fetcher struct {
 	// FQDN of the policy server to query. If not empty, Fetcher will query on
 	// port 3000. Useful for out-of-cluster debugging
 	policyServerURL string
-	// We use two different clients to facilitate the interaction with
-	// the discovery API. Therefore, the clientset is used to call the discovery
-	// API and see if a resource is namespaced or not. While the dynamicClient
-	// client is used to fetch resource data.
+	// clientset is used to call the discovery API and see if a resource is
+	// namespaced or not
 	clientset kubernetes.Interface
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -64,7 +64,7 @@ func NewScanner(policiesFetcher PoliciesFetcher, resourcesFetcher ResourcesFetch
 
 // ScanNamespace scans resources for a given namespace
 func (s *Scanner) ScanNamespace(nsName string) error {
-	log.Info().Str("namespace", nsName).Msg("scan started")
+	log.Info().Str("namespace", nsName).Msg("namespace scan started")
 
 	namespace, err := s.policiesFetcher.GetNamespace(nsName)
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 			log.Error().Err(err).Msg("error adding PolicyReport to store")
 		}
 	}
-	log.Info().Str("namespace", nsName).Msg("scan finished")
+	log.Info().Str("namespace", nsName).Msg("namespace scan finished")
 
 	if s.printJSON {
 		str, err := s.reportStore.ToJSON()
@@ -116,6 +116,13 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 		fmt.Println(str)
 	}
 	return nil
+}
+
+// ScanAllNamespaces scans resources for all namespaces
+func (s *Scanner) ScanAllNamespaces() error {
+	// for all namespaces not on the skip-ns list, call ScanNamespace()
+
+	return errors.New("scanning all namespaces is not implemented yet. Please pass the --namespace flag to scan a namespace")
 }
 
 func (s *Scanner) ScanClusterWideResources() error {
@@ -286,9 +293,4 @@ func sendAdmissionReviewToPolicyServer(url *url.URL, admissionRequest *admv1.Adm
 		return nil, fmt.Errorf("cannot deserialize the audit review response: %w", err)
 	}
 	return &admissionReview, nil
-}
-
-// ScanAllNamespaces scans resources for all namespaces
-func (s *Scanner) ScanAllNamespaces() error {
-	return errors.New("scanning all namespaces is not implemented yet. Please pass the --namespace flag to scan a namespace")
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -64,7 +64,10 @@ func NewScanner(policiesFetcher PoliciesFetcher, resourcesFetcher ResourcesFetch
 	return &Scanner{policiesFetcher, resourcesFetcher, *report, http.Client{}, printJSON}, nil
 }
 
-// ScanNamespace scans resources for a given namespace
+// ScanNamespace scans resources for a given namespace.
+// Returns errors if there's any when fetching policies or resources, but only
+// logs them if there's a problem auditing the resource of saving the Report or
+// Result, so it can continue with the next audit, or next Result.
 func (s *Scanner) ScanNamespace(nsName string) error {
 	log.Info().Str("namespace", nsName).Msg("namespace scan started")
 
@@ -142,6 +145,10 @@ func (s *Scanner) ScanAllNamespaces() error {
 	return errs
 }
 
+// ScanClusterWideResources scans all cluster wide resources.
+// Returns errors if there's any when fetching policies or resources, but only
+// logs them if there's a problem auditing the resource of saving the Report or
+// Result, so it can continue with the next audit, or next Result.
 func (s *Scanner) ScanClusterWideResources() error {
 	log.Info().Msg("cluster wide scan started")
 	policies, skippedNum, err := s.policiesFetcher.GetClusterAdmissionPolicies()

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -30,9 +30,6 @@ type PoliciesFetcher interface {
 	GetNamespace(namespace string) (*v1.Namespace, error)
 	// GetAuditedNamespaces gets all namespaces, minus those in the skipped ns list
 	GetAuditedNamespaces() (*v1.NamespaceList, error)
-	// GetPoliciesForAllNamespaces gets all auditable policies for all
-	// namespaces, and the number of skipped policies
-	GetPoliciesForAllNamespaces() ([]policiesv1.Policy, int, error)
 	// Get all auditable ClusterAdmissionPolicies and the number of skipped policies
 	GetClusterAdmissionPolicies() ([]policiesv1.Policy, int, error)
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/52

- feat: Adjust flag behaviour
  Not passing any flag: Scan cluster wide and all ns.
  Passing both `--cluster` and `--namespace foo`: error.
- feat: Add new --skipped-ns flag, Add Fetcher.skippedNS
  Add new flag of comma separated list of namespace names to be skipped.
  Add new field to policies.Fetcher{}, Fetcher.skippedNs.
- feat: Add fetcher.GetAuditedNamespaces(), implement scan all ns

## Test

Tested locally. Example:
```
./bin/audit-scanner -l debug -u https://localhost:3000 -p -s "default,kubewarden"
```

## Additional Information

### Tradeoff

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
