### PR TITLE
Updates cosign to v2.

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -34,19 +34,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@v2.8.1
+      - uses: sigstore/cosign-installer@v3
+
       - name: Sign the images
         run: |
-          cosign sign \
+          cosign sign --yes \
             ${{needs.build.outputs.repository}}@${{needs.build.outputs.digest}}
-        env:
-          COSIGN_EXPERIMENTAL: 1
 
-      - uses: sigstore/cosign-installer@v2.8.1
       - name: Sign the SBOM
         run: |
           tag=$(echo '${{needs.build.outputs.digest}}' | sed 's/:/-/g')
-          cosign sign \
+          cosign sign --yes \
             "${{needs.build.outputs.repository}}:$tag.sbom"
-        env:
-          COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: go install sigs.k8s.io/bom/cmd/bom@v0.2.2
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v3
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -56,11 +56,9 @@ jobs:
 
       - name: Sign BOM file
         run: |
-          cosign sign-blob --output-certificate audit-scanner-sbom.spdx.cert \
+          cosign sign-blob --yes --output-certificate audit-scanner-sbom.spdx.cert \
             --output-signature audit-scanner-sbom.spdx.sig \
             audit-scanner-sbom.spdx
-        env:
-          COSIGN_EXPERIMENTAL: 1
 
       - name: Get latest release tag
         id: get_last_release_tag

--- a/.github/workflows/reusable-container-image.yml
+++ b/.github/workflows/reusable-container-image.yml
@@ -64,7 +64,7 @@ jobs:
       -
         name: Install Cosign
         if: ${{ inputs.generate-sbom == true }}
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v3
       -
         name: Retrieve tag name
         if: ${{ startsWith(github.ref, 'refs/heads/') }}


### PR DESCRIPTION
## Description

Updates the CI scripts updating the cosign-installer to v3. Thus, the cosign version now is v2. Which has breaking changes requiring some changes on how the command is called and removing the need of using environment variable to enable keyless signature.

Related to https://github.com/kubewarden/kubewarden-controller/issues/411
