### PR TITLE
fix: Don't print errors on first run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.53.3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,7 @@ linters:
     - lll # long lines
     - wrapcheck
     - godox
+    - depguard
     # https://github.com/golangci/golangci-lint/issues/541
     - interfacer
     - interfacebloat

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BIN_DIR := $(abspath $(ROOT_DIR)/bin)
 IMG ?= audit-scanner:latest
 
-GOLANGCI_LINT_VER := v1.52.2
+GOLANGCI_LINT_VER := v1.53.3
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(BIN_DIR)/$(GOLANGCI_LINT_BIN)
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -152,7 +152,7 @@ func (s *Scanner) ScanClusterWideResources() error {
 	if err != nil {
 		return err
 	}
-	log.Debug().
+	log.Info().
 		Dict("dict", zerolog.Dict().
 			Int("policies to evaluate", len(policies)).
 			Int("policies skipped", skippedNum),
@@ -242,7 +242,7 @@ func auditResource(toBeAudited *resources.AuditableResources, resourcesFetcher R
 	for _, policy := range toBeAudited.Policies {
 		url, err := resourcesFetcher.GetPolicyServerURLRunningPolicy(context.Background(), policy)
 		if err != nil {
-			log.Error().Err(err)
+			log.Error().Err(err).Msg("error obtaining polucy-server URL")
 			continue
 		}
 		for _, resource := range toBeAudited.Resources {
@@ -287,7 +287,6 @@ func auditResource(toBeAudited *resources.AuditableResources, resourcesFetcher R
 
 func sendAdmissionReviewToPolicyServer(url *url.URL, admissionRequest *admv1.AdmissionReview, httpClient *http.Client) (*admv1.AdmissionReview, error) {
 	payload, err := json.Marshal(admissionRequest)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -95,8 +95,8 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 	// old policy report to be used as cache
 	previousNamespacedReport, err := s.reportStore.GetPolicyReport(nsName)
 	if err != nil {
-		log.Error().Err(err).Str("namespace", nsName).
-			Msg("error getting previous PolicyReport from store")
+		log.Info().Err(err).Str("namespace", nsName).
+			Msg("no pre-existing PolicyReport, will create one at the end of the scan")
 	}
 
 	// Iterate through all auditableResources. Each item contains a list of resources and the policies that would need
@@ -167,7 +167,7 @@ func (s *Scanner) ScanClusterWideResources() error {
 	// old policy report to be used as cache
 	previousClusterReport, err := s.reportStore.GetClusterPolicyReport(constants.DefaultClusterwideReportName)
 	if err != nil {
-		log.Error().Err(err).Msg("error getting ClusterPolicyReport from store")
+		log.Info().Err(err).Msg("no-prexisting ClusterPolicyReport, will create one at the end of the scan")
 	}
 	// Iterate through all auditableResources. Each item contains a list of resources and the policies that would need
 	// to evaluate them.


### PR DESCRIPTION
On all first runs, there aren't any previous policy reports. IMO this shouldn't be an error as it is expected.
On subsequent runs, this could also happen, if a user manually deletes policy reports. We should downgrade then to Info.

## Description
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
No need.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
