### PR TITLE
fix: Warn instead of panic when API resource not found or forbidden

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ PolicyReports CRDs. And the audit feature is disabled by default.
 
 Then:
 
-``` console
+```console
 kubectl port-forward -n kubewarden service/policy-server-default 3000:8443
 
 ./bin/audit-scanner \
@@ -16,9 +16,34 @@ kubectl port-forward -n kubewarden service/policy-server-default 3000:8443
 
 or to get results in JSON:
 
-``` console
+```console
 ./bin/audit-scanner \
   -k kubewarden --namespace default \
   --policy-server-url https://localhost:3000 \
   -l debug --print
+```
+
+### Run against audit-scanner SA
+
+To run with the `audit-scanner` ServiceAccount, install `kubewarden-controller`
+chart, and, with the help of the kubectl [view-serviceaccount-kubeconfig](https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin)
+plugin:
+
+```console
+kubectl create token audit-scanner -n kubewarden | kubectl view-serviceaccount-kubeconfig > ./kubeconfig
+```
+
+If needed, patch the resulting kubeconfig, adding the missing
+`certificate-authority`. E.g:
+
+```yaml
+clusters:
+- cluster:
+  certificate-authority: /home/vic/.minikube/ca.crt
+```
+
+And use it:
+
+```console
+export KUBECONFIG=./kubeconfig
 ```

--- a/internal/policies/fetcher.go
+++ b/internal/policies/fetcher.go
@@ -194,7 +194,7 @@ func (f *Fetcher) getAdmissionPolicies(namespace string) ([]policiesv1.Admission
 	return policies.Items, nil
 }
 
-func newClient() (client.Client, error) { //nolint
+func newClient() (client.Client, error) { //nolint:ireturn
 	config := ctrl.GetConfigOrDie()
 	customScheme := scheme.Scheme
 	customScheme.AddKnownTypes(

--- a/internal/resources/fetcher_test.go
+++ b/internal/resources/fetcher_test.go
@@ -735,13 +735,13 @@ func TestLackOfPermsWhenGettingResources(t *testing.T) {
 	// simulate lacking permissions when listing pods or namespaces. This should
 	// make the filtering skip these resources, and produce no error
 	dynamicClient.PrependReactor("list", "pods",
-		func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		func(action clienttesting.Action) (bool, runtime.Object, error) {
 			return true, nil, apimachineryerrors.NewForbidden(schema.GroupResource{
 				Resource: "pods",
 			}, "", errors.New("reason"))
 		})
 	dynamicClient.PrependReactor("list", "namespaces",
-		func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		func(action clienttesting.Action) (bool, runtime.Object, error) {
 			return true, nil, apimachineryerrors.NewForbidden(schema.GroupResource{
 				Resource: "namespaces",
 			}, "", errors.New("reason"))
@@ -767,7 +767,7 @@ func TestLackOfPermsWhenGettingResources(t *testing.T) {
 	fakeClientSet := fakekubernetes.NewSimpleClientset()
 	fakeClientSet.Resources = []*metav1.APIResourceList{&apiResourceList}
 
-	// the pairs policies,resources should be empty, as pods,namespaces have
+	// the pairs (policies,resources) should be empty, as (pods,namespaces) have
 	// been skipped because of lack of permissions
 	expectedP1 := []AuditableResources{}
 

--- a/internal/resources/fetcher_test.go
+++ b/internal/resources/fetcher_test.go
@@ -115,6 +115,26 @@ func TestGetResourcesForPolicies(t *testing.T) {
 
 	dynamicClient := fake.NewSimpleDynamicClient(customScheme, &policy1, &pod1, &pod2, &pod3, &deployment1)
 
+	apiResourceList := metav1.APIResourceList{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:         "namespaces",
+				SingularName: "namespace",
+				Kind:         "Namespace",
+				Namespaced:   false,
+			},
+			{
+				Name:         "pods",
+				SingularName: "pod",
+				Kind:         "Pod",
+				Namespaced:   true,
+			},
+		},
+	}
+	fakeClientSet := fakekubernetes.NewSimpleClientset()
+	fakeClientSet.Resources = []*metav1.APIResourceList{&apiResourceList}
+
 	unstructuredPod1 := map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "Pod",
@@ -155,7 +175,7 @@ func TestGetResourcesForPolicies(t *testing.T) {
 		Resources: []unstructured.Unstructured{{Object: unstructuredPod3}},
 	}}
 
-	fetcher := Fetcher{dynamicClient, "", "", nil}
+	fetcher := Fetcher{dynamicClient, "", "", fakeClientSet}
 
 	tests := []struct {
 		name      string

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -94,9 +94,12 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 	namespacedsReport.Summary.Skip = skippedNum
 	// old policy report to be used as cache
 	previousNamespacedReport, err := s.reportStore.GetPolicyReport(nsName)
-	if err != nil {
-		log.Info().Err(err).Str("namespace", nsName).
-			Msg("no pre-existing PolicyReport, will create one at the end of the scan")
+	if errors.Is(err, constants.ErrResourceNotFound) {
+		log.Info().Str("namespace", nsName).
+			Msg("no pre-existing PolicyReport, will create one at end of the scan if needed")
+	} else if err != nil {
+		log.Err(err).Str("namespace", nsName).
+			Msg("error when obtaining PolicyReport")
 	}
 
 	// Iterate through all auditableResources. Each item contains a list of resources and the policies that would need

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -210,7 +210,7 @@ func auditClusterResource(resource *resources.AuditableResources, resourcesFetch
 					Str("policyUID", string(policy.GetUID())).
 					Str("resource", resource.GetName()).
 					Str("resourceResourceVersion", resource.GetResourceVersion()),
-				).Msg("Previous result found. Reuse result")
+				).Msg("Previous result found. Reusing result")
 				continue
 			}
 			admissionRequest := resources.GenerateAdmissionReview(resource)
@@ -259,7 +259,7 @@ func auditResource(toBeAudited *resources.AuditableResources, resourcesFetcher R
 					Str("policyUID", string(policy.GetUID())).
 					Str("resource", resource.GetName()).
 					Str("resourceResourceVersion", resource.GetResourceVersion()),
-				).Msg("Previous result found. Reuse result")
+				).Msg("Previous result found. Reusing result")
 				continue
 			}
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/68

- [fix: Skip clusterwide resources in getResourcesForPolicies](https://github.com/kubewarden/audit-scanner/pull/73/commits/478f74fd621fb4860a5c2255948b966320c15570)
- [fix: Warn instead of panic when API resource not found or forbidden](https://github.com/kubewarden/audit-scanner/pull/73/commits/6682cbd733333ff2c24a516d77c2b78295f07580)
- Add tests

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added unit tests.

Performed manual integration tests when developing:
1. Deployed kubewarden helm charts from kubewarden/helm-charts@main:
```
helm upgrade -i --wait --namespace kubewarden --create-namespace kubewarden-crds ./charts/kubewarden-crds
helm upgrade -i --wait --namespace kubewarden --create-namespace kubewarden-controller ./charts/kubewarden-controller --set auditScanner.cronJob.schedule="*/3 * * * *" --set auditScanner.enable=true
helm upgrade -i --wait --namespace kubewarden --create-namespace kubewarden-defaults ./charts/kubewarden-defaults --set recommendedPolicies.enabled=True --set recommendedPolicies.defaultPolicyMode=monitor
```
2. Deployed a labeled namespace (which is clusterwide), and a safe-labels policy that checks pods, namespaces, an unexistent resource, and secrets (forbidden by the audit-scanner ServiceAccount we ship).
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: demo2
  labels:
    cost-center: "123"
---
apiVersion: policies.kubewarden.io/v1
kind: ClusterAdmissionPolicy
metadata:
  annotations:
    io.kubewarden.policy.category: Resource validation
    io.kubewarden.policy.severity: low
  name: safe-labels
spec:
  module: registry://ghcr.io/kubewarden/tests/safe-labels:v0.1.13
  settings:
    denied_labels:
      - cost-center
  mode: protect
  rules:
    - apiGroups: [""]
      apiVersions: ["v1"]
      resources: ["pods,namespaces, unexistent, secrets"]
      operations:
        - CREATE
  mutating: false
  backgroundAudit: true
```

3. Without the changes, we get a panic on `secrets` resource as they are forbidden.

4. With changes applied:
    Deploying the default policies, plus `safe-labels` policy targetting resources `[pods, Pods, namespaces, secrets]` (note that `Pods` is incorrect), we get the following WARN messages, for both `Pod` (API resource not found) and `secrets` (API resource forbidden, unknown GVK or ServiceAccount lacks permissions):

```
audit-scanner-28171311-ls6hw {"level":"info","time":"2023-07-25T09:51:01Z","message":"cluster wide scan started"}
audit-scanner-28171311-ls6hw {"level":"info","dict":{"policies to evaluate":7,"policies skipped":0},"time":"2023-07-25T09:51:01Z","message":"cluster admission policies count"}
audit-scanner-28171311-ls6hw {"level":"warn","resource GVK":"/v1, Resource=Pods","time":"2023-07-25T09:51:01Z","message":"API resource not found"}
audit-scanner-28171311-ls6hw {"level":"info","time":"2023-07-25T09:51:01Z","message":"scan finished"}
audit-scanner-28171311-ls6hw {"level":"info","dict":{"report name":"polr-clusterwide","report ns":"","summary":"{\"pass\":7,\"fail\":1,\"warn\":0,\"error\":0,\"skip\":0}"},"time":"2023-07-25T09:51:01Z","message":"updated ClusterPolicyReport"}
audit-scanner-28171311-ls6hw {"level":"info","time":"2023-07-25T09:51:01Z","message":"all-namespaces scan started"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"default","time":"2023-07-25T09:51:01Z","message":"namespace scan started"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"default","dict":{"policies to evaluate":7,"policies skipped":0},"time":"2023-07-25T09:51:01Z","message":"policy count"}
audit-scanner-28171311-ls6hw {"level":"warn","resource GVK":"/v1, Resource=Pods","time":"2023-07-25T09:51:01Z","message":"API resource not found"}
audit-scanner-28171311-ls6hw {"level":"warn","dict":{"resource GVK":"/v1, Resource=secrets","ns":"default"},"time":"2023-07-25T09:51:01Z","message":"API resource forbidden, unknown GVK or ServiceAccount lacks permissions"}
audit-scanner-28171311-ls6hw {"level":"info","dict":{"report name":"polr-ns-default","report ns":"default","report resourceVersion":"88451","summary":"{\"pass\":6,\"fail\":1,\"warn\":0,\"error\":0,\"skip\":0}"},"time":"2023-07-25T09:51:01Z","message":"updated PolicyReport"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"default","time":"2023-07-25T09:51:01Z","message":"namespace scan finished"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"demo2","time":"2023-07-25T09:51:01Z","message":"namespace scan started"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"demo2","dict":{"policies to evaluate":7,"policies skipped":0},"time":"2023-07-25T09:51:01Z","message":"policy count"}
audit-scanner-28171311-ls6hw {"level":"warn","resource GVK":"/v1, Resource=Pods","time":"2023-07-25T09:51:01Z","message":"API resource not found"}
audit-scanner-28171311-ls6hw {"level":"warn","dict":{"resource GVK":"/v1, Resource=secrets","ns":"demo2"},"time":"2023-07-25T09:51:01Z","message":"API resource forbidden, unknown GVK or ServiceAccount lacks permissions"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"demo2","time":"2023-07-25T09:51:01Z","message":"no pre-existing PolicyReport, will create one at end of the scan if needed"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"demo2","time":"2023-07-25T09:51:01Z","message":"namespace scan finished"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"policy-reporter","time":"2023-07-25T09:51:01Z","message":"namespace scan started"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"policy-reporter","dict":{"policies to evaluate":7,"policies skipped":0},"time":"2023-07-25T09:51:01Z","message":"policy count"}
audit-scanner-28171311-ls6hw {"level":"warn","resource GVK":"/v1, Resource=Pods","time":"2023-07-25T09:51:01Z","message":"API resource not found"}
audit-scanner-28171311-ls6hw {"level":"warn","dict":{"resource GVK":"/v1, Resource=secrets","ns":"policy-reporter"},"time":"2023-07-25T09:51:01Z","message":"API resource forbidden, unknown GVK or ServiceAccount lacks permissions"}
audit-scanner-28171311-ls6hw {"level":"info","dict":{"report name":"polr-ns-policy-reporter","report ns":"policy-reporter","report resourceVersion":"88454","summary":"{\"pass\":6,\"fail\":0,\"warn\":0,\"error\":0,\"skip\":0}"},"time":"2023-07-25T09:51:02Z","message":"updated PolicyReport"}
audit-scanner-28171311-ls6hw {"level":"info","dict":{"report name":"polr-ns-policy-reporter","report ns":"policy-reporter","report resourceVersion":"88456","summary":"{\"pass\":12,\"fail\":0,\"warn\":0,\"error\":0,\"skip\":0}"},"time":"2023-07-25T09:51:02Z","message":"updated PolicyReport"}
audit-scanner-28171311-ls6hw {"level":"info","dict":{"report name":"polr-ns-policy-reporter","report ns":"policy-reporter","report resourceVersion":"88457","summary":"{\"pass\":26,\"fail\":0,\"warn\":0,\"error\":0,\"skip\":0}"},"time":"2023-07-25T09:51:03Z","message":"updated PolicyReport"}
audit-scanner-28171311-ls6hw {"level":"info","namespace":"policy-reporter","time":"2023-07-25T09:51:03Z","message":"namespace scan finished"}
audit-scanner-28171311-ls6hw {"level":"info","time":"2023-07-25T09:51:03Z","message":"all-namespaces scan finished"}
Stream closed EOF for kubewarden/audit-scanner-28171311-ls6hw (audit-scanner)
```


## Additional Information

I recommend review per commit.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

Refactor the filter packages after first MVP. Opened https://github.com/kubewarden/audit-scanner/issues/74.



