### PR TITLE
feat: Add `--insecure-ssl`, `--filepath-cacert` flags, consume ca cert

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,7 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 			if err != nil {
 				return err
 			}
-			scanner, err := scanner.NewScanner(policiesFetcher, resourcesFetcher, printJSON)
+			scanner, err := scanner.NewScanner(policiesFetcher, resourcesFetcher, printJSON, insecureSSL, caCertFile)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,10 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	// make sure we always get json formatted errors, even for flag errors
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal().Err(err).Msg("Error on cmd.Execute()")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ type Scanner interface {
 	ScanClusterWideResources() error
 }
 
+// log level
 var level logconfig.Level
 
 // print result of scan as JSON to stdout
@@ -31,8 +32,8 @@ var printJSON bool
 // list of namespaces to be skipped from scan
 var skippedNs []string
 
-// rootCmd represents the base command when called without any subcommands
 var (
+	// rootCmd represents the base command when called without any subcommands
 	rootCmd = &cobra.Command{
 		Use:   "audit-scanner",
 		Short: "Reports evaluation of existing Kubernetes resources with your already deployed Kubewarden policies",
@@ -107,10 +108,10 @@ func startScanner(namespace string, clusterWide bool, scanner Scanner) error {
 
 func init() {
 	rootCmd.Flags().StringP("namespace", "n", "", "namespace to be evaluated")
-	rootCmd.Flags().BoolP("cluster", "c", false, "Scan cluster wide resources")
-	rootCmd.Flags().StringP("kubewarden-namespace", "k", defaultKubewardenNamespace, "namespace where the Kubewarden components (e.g. Policy Server) are installed (required)")
-	rootCmd.Flags().StringP("policy-server-url", "u", "", "Full URL to the PolicyServers, for example https://localhost:3000. Audit scanner will query the needed HTTP path. Useful for out-of-cluster debugging")
+	rootCmd.Flags().BoolP("cluster", "c", false, "scan cluster wide resources")
+	rootCmd.Flags().StringP("kubewarden-namespace", "k", defaultKubewardenNamespace, "namespace where the Kubewarden components (e.g. PolicyServer) are installed (required)")
+	rootCmd.Flags().StringP("policy-server-url", "u", "", "URI to the PolicyServers the Audit Scanner will query. Example: https://localhost:3000. Useful for out-of-cluster debugging")
 	rootCmd.Flags().VarP(&level, "loglevel", "l", fmt.Sprintf("level of the logs. Supported values are: %v", logconfig.SupportedValues))
 	rootCmd.Flags().BoolVarP(&printJSON, "print", "p", false, "print result of scan in JSON to stdout")
-	rootCmd.Flags().StringSliceVarP(&skippedNs, "ignore-namespaces", "i", nil, "Comma separated list of namespace names to be skipped from scan")
+	rootCmd.Flags().StringSliceVarP(&skippedNs, "ignore-namespaces", "i", nil, "comma separated list of namespace names to be skipped from scan. This flag can be repeated")
 }

--- a/internal/policies/fetcher.go
+++ b/internal/policies/fetcher.go
@@ -194,7 +194,7 @@ func (f *Fetcher) getAdmissionPolicies(namespace string) ([]policiesv1.Admission
 	return policies.Items, nil
 }
 
-func newClient() (client.Client, error) { //nolint:ireturn
+func newClient() (client.Client, error) { //nolint
 	config := ctrl.GetConfigOrDie()
 	customScheme := scheme.Scheme
 	customScheme.AddKnownTypes(

--- a/internal/policies/fetcher_test.go
+++ b/internal/policies/fetcher_test.go
@@ -370,7 +370,7 @@ var nsKubewarden = v1.Namespace{
 	},
 }
 
-func mockClient(initObjs ...k8sClient.Object) k8sClient.Client { //nolint:ireturn
+func mockClient(initObjs ...k8sClient.Object) k8sClient.Client { //nolint
 	customScheme := scheme.Scheme
 	customScheme.AddKnownTypes(schema.GroupVersion{Group: constants.KubewardenPoliciesGroup, Version: constants.KubewardenPoliciesVersion}, &policiesv1.ClusterAdmissionPolicy{}, &policiesv1.AdmissionPolicy{}, &policiesv1.ClusterAdmissionPolicyList{}, &policiesv1.AdmissionPolicyList{})
 	metav1.AddToGroupVersion(customScheme, schema.GroupVersion{Group: constants.KubewardenPoliciesGroup, Version: constants.KubewardenPoliciesVersion})

--- a/internal/resources/fetcher.go
+++ b/internal/resources/fetcher.go
@@ -55,7 +55,7 @@ func NewFetcher(kubewardenNamespace string, policyServerURL string) (*Fetcher, e
 	dynamicClient := dynamic.NewForConfigOrDie(config)
 	clientset := kubernetes.NewForConfigOrDie(config)
 	if policyServerURL != "" {
-		log.Info().Msg(fmt.Sprintf("Querying PolicyServers at %s for debugging purposes. Don't forget to start `kwctl port-forward` if needed", policyServerURL))
+		log.Info().Msg(fmt.Sprintf("querying PolicyServers at %s for debugging purposes. Don't forget to start `kwctl port-forward` if needed", policyServerURL))
 	}
 	return &Fetcher{dynamicClient, kubewardenNamespace, policyServerURL, clientset}, nil
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -76,11 +76,11 @@ func NewScanner(policiesFetcher PoliciesFetcher, resourcesFetcher ResourcesFetch
 	if caCertFile != "" {
 		certs, err := os.ReadFile(caCertFile)
 		if err != nil {
-			log.Fatal().Msg(fmt.Sprintf("failed to read file %q with CA cert: %v", caCertFile, err))
+			return nil, fmt.Errorf("failed to read file %q with CA cert: %w", caCertFile, err)
 		}
 		// Append our cert to the in-app cert pool
 		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-			log.Fatal().Msg("failed to append cert to in-app RootCAs trust store")
+			return nil, errors.New("failed to append cert to in-app RootCAs trust store")
 		}
 		log.Debug().Str("ca-cert-file", caCertFile).
 			Msg("appended cert file to in-app RootCAs trust store")
@@ -91,7 +91,7 @@ func NewScanner(policiesFetcher PoliciesFetcher, resourcesFetcher ResourcesFetch
 	httpClient.Transport = http.DefaultTransport
 	transport, ok := httpClient.Transport.(*http.Transport)
 	if !ok {
-		log.Fatal().Msg("failed to build httpClient: failed http.Transport type assertion")
+		return nil, errors.New("failed to build httpClient: failed http.Transport type assertion")
 	}
 	transport.TLSClientConfig = &tls.Config{
 		RootCAs:    rootCAs, // our augmented in-app cert pool

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -81,7 +81,7 @@ func NewScanner(policiesFetcher PoliciesFetcher, resourcesFetcher ResourcesFetch
 		// Read in the cert file
 		certs, err := os.ReadFile(caCertFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file %q with CA cert: %w", caCertFile, err)
+			log.Fatal().Msg(fmt.Sprintf("failed to read file %q with CA cert: %v", caCertFile, err))
 		}
 		// Append our cert to the inherited system pool
 		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -71,7 +71,7 @@ func NewScanner(policiesFetcher PoliciesFetcher, resourcesFetcher ResourcesFetch
 	if insecureClient {
 		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint
 		httpClient = http.Client{Transport: tr}
-		log.Info().Msg("connecting to PolicyServers endpoints in insecure SSL mode")
+		log.Warn().Msg("connecting to PolicyServers endpoints without validating TLS connection")
 	} else {
 		// Get the SystemCertPool, continue with an empty pool on error
 		rootCAs, _ := x509.SystemCertPool()


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Partial implementation of https://github.com/kubewarden/audit-scanner/issues/64

`--insecure-ssl` flag is false by default.

`--filepath-cacert` flag is "./policy-server-ca-cert" by default.
If `KUBEWARDEN_CACERT_PEM_POLICYSERVERS` is set, it will overwrite the
default and whatever value is passed as flag.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tested locally. I don't see the need to add unit-tests, and integration tests aren't much useful either. I could add an e2e test without a kubeapi, where I provide a file that is not a PEM cert, and see it crash.

```console
$ audit-scanner --help
Scans resources in your kubernetes cluster with your already deployed Kubewarden policies.
Each namespace will have a PolicyReport with the outcome of the scan for resources within this namespace.
There will be a ClusterPolicyReport with results for cluster-wide resources.

Usage:
  audit-scanner [flags]

Flags:
  -c, --cluster                       scan cluster wide resources
  -f, --filepath-cacert string        File path to CA cert in PEM format of PolicyServer endpoints (default "/pki/policy-server-ca-cert")
  -h, --help                          help for audit-scanner
  -i, --ignore-namespaces strings     comma separated list of namespace names to be skipped from scan. This flag can be repeated
      --insecure-ssl                  skip SSL cert validation when connecting to PolicyServers endpoints. Useful for development
  -k, --kubewarden-namespace string   namespace where the Kubewarden components (e.g. PolicyServer) are installed (required) (default "kubewarden")
  -l, --loglevel string               level of the logs. Supported values are: [trace debug info warn error fatal] (default "info")
  -n, --namespace string              namespace to be evaluated
  -u, --policy-server-url string      URI to the PolicyServers the Audit Scanner will query. Example: https://localhost:3000. Useful for out-of-cluster debugging
  -p, --print                         print result of scan in JSON to stdout

```


```console
$ ./bin/audit-scanner -k kubewarden --policy-server-url https://localhost:3000 -l info
{"level":"info","time":"2023-07-27T18:05:16+02:00","message":"querying PolicyServers at https://localhost:3000 for debugging purposes. Don't forget to start `kwctl port-forward` if needed"}
Error: failed to read file "/pki/policy-server-ca-cert" with CA cert: open /pki/policy-server-ca-cert: no such file or directory
```

```console
$ KUBEWARDEN_CACERT_PEM_POLICYSERVERS=/home/vic/ca-cert ./bin/audit-scanner -k kubewarden --policy-server-url https://localhost:3000 -l info
{"level":"info","time":"2023-07-27T18:05:39+02:00","message":"querying PolicyServers at https://localhost:3000 for debugging purposes. Don't forget to start `kwctl port-forward` if needed"}
{"level":"info","time":"2023-07-27T18:05:39+02:00","message":"cluster wide scan started"}
```

```console
$ ./bin/audit-scanner -k kubewarden --policy-server-url https://localhost:3000 -l info --filepath-cacert /home/vic/changelog.md
{"level":"info","time":"2023-07-27T18:09:48+02:00","message":"querying PolicyServers at https://localhost:3000 for debugging purposes. Don't forget to start `kwctl port-forward` if needed"}
{"level":"fatal","time":"2023-07-27T18:09:48+02:00","message":"failed to append cert to in-app RootCAs trust store"}
```

```console
$ ./bin/audit-scanner -k kubewarden --policy-server-url https://localhost:3000 -l info --insecure-ssl
{"level":"info","time":"2023-07-27T18:06:16+02:00","message":"querying PolicyServers at https://localhost:3000 for debugging purposes. Don't forget to start `kwctl port-forward` if needed"}
{"level":"info","time":"2023-07-27T18:06:16+02:00","message":"connecting to PolicyServers endpoints in insecure SSL mode"}
{"level":"info","time":"2023-07-27T18:06:16+02:00","message":"cluster wide scan started"}
```


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
