### PR TITLE
deps: Pin wg-policy-prototypes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,8 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - wastedassign
+    # disabled because of replacement
+    - gomoddirectives
 
 linters-settings:
   cyclop:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,10 @@ require (
 	sigs.k8s.io/wg-policy-prototypes v0.0.0-20230505033312-51c21979086a
 )
 
+replace (
+	sigs.k8s.io/wg-policy-prototypes => sigs.k8s.io/wg-policy-prototypes v0.0.0-20230505033312-51c21979086a
+)
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect


### PR DESCRIPTION



## Description

Upstream is untagged, and we need to consume the PolicyReports v1alpha2.
Follow-up of https://github.com/kubewarden/audit-scanner/pull/86

Hopefully this will make the bot not try to bump that dep.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
