### PR TITLE
chore: Ignore wg-policy-prototypes in renovatebot 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "config:base",
     "helpers:pinGitHubActionDigests"
+  ],
+  "ignoreDeps": [
+    "sigs.k8s.io/wg-policy-prototypes"
   ]
 }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Supersedes https://github.com/kubewarden/audit-scanner/pull/89

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
We will see once we retrigger renovate

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
