### PR TITLE
refactor!: Rename `--print` flag to `--output-scan`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ or to get results in JSON:
 ./bin/audit-scanner \
   -k kubewarden --namespace default \
   --policy-server-url https://localhost:3000 \
-  -l debug --print
+  -l debug --output-scan
 ```
 
 ### Run against audit-scanner SA
@@ -38,8 +38,8 @@ If needed, patch the resulting kubeconfig, adding the missing
 
 ```yaml
 clusters:
-- cluster:
-  certificate-authority: /home/vic/.minikube/ca.crt
+  - cluster:
+    certificate-authority: /home/vic/.minikube/ca.crt
 ```
 
 And use it:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,7 +124,7 @@ func init() {
 	rootCmd.Flags().StringP("kubewarden-namespace", "k", defaultKubewardenNamespace, "namespace where the Kubewarden components (e.g. PolicyServer) are installed (required)")
 	rootCmd.Flags().StringP("policy-server-url", "u", "", "URI to the PolicyServers the Audit Scanner will query. Example: https://localhost:3000. Useful for out-of-cluster debugging")
 	rootCmd.Flags().VarP(&level, "loglevel", "l", fmt.Sprintf("level of the logs. Supported values are: %v", logconfig.SupportedValues))
-	rootCmd.Flags().BoolVarP(&printJSON, "print", "p", false, "print result of scan in JSON to stdout")
+	rootCmd.Flags().BoolVarP(&printJSON, "output-scan", "o", false, "print result of scan in JSON to stdout")
 	rootCmd.Flags().StringSliceVarP(&skippedNs, "ignore-namespaces", "i", nil, "comma separated list of namespace names to be skipped from scan. This flag can be repeated")
 	rootCmd.Flags().BoolVar(&insecureSSL, "insecure-ssl", false, "skip SSL cert validation when connecting to PolicyServers endpoints. Useful for development")
 	rootCmd.Flags().StringP("extra-ca", "f", "", "File path to CA cert in PEM format of PolicyServer endpoints")


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/helm-charts/pull/282.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

No need.

## Additional Information

This signifies that using `--output-scan` can be consumed by end users.
I have checked the source code to ensure that the audit-scanner binary doesn't print to stdout or stderr in a way that isn't JSON formatted (unless it suddenly catches a panic and one gets an exception).
Also, the current config of `golangci-lint` forbids `fmt.Println` and the like.

This should provide reasonable certainty that stdout can be consumed by end users.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

