### PR TITLE
fix: Set `AdmissionRequest{}.RequestKind`

### DIFF
--- a/internal/resources/admission_request.go
+++ b/internal/resources/admission_request.go
@@ -22,6 +22,11 @@ func GenerateAdmissionRequest(resource unstructured.Unstructured) *admv1.Admissi
 			Version:  groupVersionKind.Version,
 			Resource: groupVersionKind.Kind,
 		},
+		RequestKind: &metav1.GroupVersionKind{
+			Group:   groupVersionKind.Group,
+			Version: groupVersionKind.Version,
+			Kind:    groupVersionKind.Kind,
+		},
 		Operation: admv1.Create,
 		Namespace: resource.GetNamespace(),
 		Object: runtime.RawExtension{


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/148.

`RequestKind` matches the type of original API request, in the case that there's several kinds that match the same object (e.g: deployments can be modified via `apps/v1` ad `apps/v1beta1`), and conversion was performed.

The `AdmissionRequests` use `AdmissionRequest.Kind` to match the rule of the webhook registered for, hence `RequestKind` is there for book-keeping.

Set `RequestKind`, which gets consumed later on in policy-server to set the metrics baggage:
https://github.com/kubewarden/policy-server/blob/63c9f32052b7ced50b4007e8ce0b5ed27392aa7f/src/worker.rs#L226

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Built an [audit-scanner image with the fix](https://github.com/users/viccuad/packages/container/test%2Faudit-scanner/154652198?tag=baggagefix) and tested that `kubewarden_policy_evaluations_total` now contain `resource_kind`:

Before:
```
kubewarden_policy_evaluations_total{accepted="true", container="otc-container", endpoint="metrics", exported_job="unknown_service", instance="10.244.0.165:8080", job="policy-server-default", mutated="false", namespace="kubewarden", pod="policy-server-default-fd79dc9-8mf6b", policy_mode="monitor", policy_name="clusterwide-no-privileged-pod", request_origin="audit", resource_namespace="prometheus", resource_request_operation="CREATE", service="policy-server-default"}
```

After:
```
kubewarden_policy_evaluations_total{accepted="false", container="otc-container", endpoint="metrics", exported_job="unknown_service", instance="10.244.0.165:8080", job="policy-server-default", mutated="false", namespace="kubewarden", pod="policy-server-default-fd79dc9-8mf6b", policy_mode="monitor", policy_name="clusterwide-no-privileged-pod", request_origin="validate",
resource_kind="Pod",    <----
 resource_namespace="default", resource_request_operation="CREATE", service="policy-server-default"}
```

Didn't add unit tests, as there's not much to do there. Integration tests would be too much.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
