### PR TITLE
feat: Build image with scratch instead of distroless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ build: fmt vet lint ## Build audit-scanner binary.
 
 .PHONY: docker-build
 docker-build: unit-tests
-	docker build -t ${IMG} .
+	DOCKER_BUILDKIT=1 docker build -t ${IMG} .


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/119

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally by running `ghcr.io/viccuad/test/audit-scanner:scratch ` in a cluster.

Checked `syft ghcr.io/viccuad/test/audit-scanner:scratch -vv`, which uses the go-module-binary-cataloger to find the deps:
```
[0001] DEBUG discovered 63 packages cataloger=go-module-binary-cataloger
(...)
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
