### PR TITLE
ci: Fix artifact upload and download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,15 +92,19 @@ jobs:
             }
             core.setFailed(`Draft release not found`)
 
-      - name: Download SBOM artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: sbom
+          pattern: sbom-*
+          path: ./
+          merge-multiple: true
 
-      - name: Download CRDs artifact
-        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
+      - name: Download CRDs artifacts
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: CRDS
+          pattern: CRDS
+          path: ./
+          merge-multiple: true
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -79,5 +79,5 @@ jobs:
       - name: Upload SBOMs as artifacts
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: sbom
+          name: sbom-${{ matrix.arch }}
           path: audit-scanner-sbom-${{ matrix.arch }}*


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
{upload,download}-artifact v4 don't accept uploading the same named artifact. Suffix their names with the arch, and download all of them at once into the same dir, as it was before.

Relates to https://github.com/kubewarden/audit-scanner/pull/160.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested on my fork: https://github.com/viccuad/audit-scanner/actions/runs/7261395579/job/19782800832

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
