### PR TITLE
feat: adds logging per `(Cluster)PolicyReport` result

### DIFF
--- a/internal/log/policy_report_logger.go
+++ b/internal/log/policy_report_logger.go
@@ -1,0 +1,67 @@
+package log
+
+import (
+	"github.com/kubewarden/audit-scanner/internal/report"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+type PolicyReportLogger struct {
+}
+
+// LogClusterPolicyReport will create a log line per each cluster-wide scanned resource
+func (l *PolicyReportLogger) LogClusterPolicyReport(report *report.ClusterPolicyReport) {
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Int("pass", report.Summary.Pass).
+			Int("fail", report.Summary.Fail).
+			Int("warn", report.Summary.Warn).
+			Int("error", report.Summary.Error).
+			Int("skip", report.Summary.Skip)).
+		Msg("ClusterPolicyReport summary")
+
+	for _, result := range report.Results {
+		log.Info().
+			Dict("dict", zerolog.Dict().
+				Str("policy", result.Policy).
+				Str("rule", result.Rule).
+				Str("result", string(result.Result)).
+				Str("message", result.Description).
+				// although subjects is a list, there's only 1 element
+				Str("resource_api_version", result.Subjects[0].APIVersion).
+				Str("resource_kind", result.Subjects[0].Kind).
+				Str("resource_namespace", result.Subjects[0].Namespace).
+				Str("resource_name", result.Subjects[0].Name).
+				Str("resource_version", result.Subjects[0].ResourceVersion)).
+			Send()
+	}
+}
+
+// LogPolicyReport will create a log line per each namespace scanned resource.
+func (l *PolicyReportLogger) LogPolicyReport(report *report.PolicyReport) {
+	log.Info().
+		Dict("dict", zerolog.Dict().
+			Str("name", report.GetName()).
+			Int("pass", report.Summary.Pass).
+			Int("fail", report.Summary.Fail).
+			Int("warn", report.Summary.Warn).
+			Int("error", report.Summary.Error).
+			Int("skip", report.Summary.Skip)).
+		Msg("PolicyReport summary")
+
+	for _, result := range report.Results {
+		log.Info().
+			Dict("dict", zerolog.Dict().
+				Str("policy", result.Policy).
+				Str("rule", result.Rule).
+				Str("result", string(result.Result)).
+				Str("message", result.Description).
+				// although subjects is a list, there's only 1 element
+				Str("resource_api_version", result.Subjects[0].APIVersion).
+				Str("resource_kind", result.Subjects[0].Kind).
+				Str("resource_namespace", result.Subjects[0].Namespace).
+				Str("resource_name", result.Subjects[0].Name).
+				Str("resource_version", result.Subjects[0].ResourceVersion)).
+			Send()
+	}
+}

--- a/internal/report/store.go
+++ b/internal/report/store.go
@@ -25,7 +25,4 @@ type PolicyReportStore interface {
 	// SaveClusterPolicyReport instantiates the ClusterPolicyReport if it doesn't exist, or
 	// updates it one is found
 	SaveClusterPolicyReport(report *ClusterPolicyReport) error
-
-	// ToJSON marshals the contents of the store into a JSON string
-	ToJSON() (string, error)
 }

--- a/internal/report/store_memory.go
+++ b/internal/report/store_memory.go
@@ -1,12 +1,9 @@
 package report
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/kubewarden/audit-scanner/internal/constants"
 	"github.com/rs/zerolog"
@@ -133,28 +130,4 @@ func (s *MemoryPolicyReportStore) SaveClusterPolicyReport(report *ClusterPolicyR
 	latestReport.Summary = report.Summary
 	latestReport.Results = report.Results
 	return s.updateClusterPolicyReport(&latestReport)
-}
-
-func (s *MemoryPolicyReportStore) listPolicyReports() ([]PolicyReport, error) { //nolint:unparam // respect the interface
-	return maps.Values(s.prCache), nil
-}
-
-func (s *MemoryPolicyReportStore) ToJSON() (string, error) {
-	recapJSON := make(map[string]interface{})
-	clusterReport, err := s.GetClusterPolicyReport(constants.DefaultClusterwideReportName)
-	if err != nil {
-		log.Error().Err(err).Msg("error fetching ClusterPolicyReport. Ignoring this error to allow user to read the namespaced reports")
-	}
-	recapJSON["cluster"] = clusterReport
-	nsReports, err := s.listPolicyReports()
-	if err != nil {
-		return "", err
-	}
-	recapJSON["namespaces"] = nsReports
-
-	marshaled, err := json.Marshal(recapJSON)
-	if err != nil {
-		return "", err
-	}
-	return string(marshaled), nil
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"os"
 
+	reportLogger "github.com/kubewarden/audit-scanner/internal/log"
+
 	"github.com/kubewarden/audit-scanner/internal/constants"
 	"github.com/kubewarden/audit-scanner/internal/report"
 	"github.com/kubewarden/audit-scanner/internal/resources"
@@ -49,6 +51,7 @@ type Scanner struct {
 	policiesFetcher  PoliciesFetcher
 	resourcesFetcher ResourcesFetcher
 	reportStore      report.PolicyReportStore
+	reportLogger     reportLogger.PolicyReportLogger
 	// http client used to make requests against the Policy Server
 	httpClient http.Client
 	outputScan bool
@@ -112,6 +115,7 @@ func NewScanner(
 		policiesFetcher:  policiesFetcher,
 		resourcesFetcher: resourcesFetcher,
 		reportStore:      store,
+		reportLogger:     reportLogger.PolicyReportLogger{},
 		httpClient:       httpClient,
 		outputScan:       outputScan,
 	}, nil
@@ -180,11 +184,7 @@ func (s *Scanner) ScanNamespace(nsName string) error {
 	log.Info().Str("namespace", nsName).Msg("namespace scan finished")
 
 	if s.outputScan {
-		str, err := s.reportStore.ToJSON()
-		if err != nil {
-			log.Error().Err(err).Msg("error marshaling reportStore to JSON")
-		}
-		fmt.Println(str) //nolint:forbidigo
+		s.reportLogger.LogPolicyReport(&namespacedsReport)
 	}
 
 	return nil
@@ -251,11 +251,7 @@ func (s *Scanner) ScanClusterWideResources() error {
 	log.Info().Msg("clusterwide resources scan finished")
 
 	if s.outputScan {
-		str, err := s.reportStore.ToJSON()
-		if err != nil {
-			log.Error().Err(err).Msg("error marshaling reportStore to JSON")
-		}
-		fmt.Println(str) //nolint:forbidigo
+		s.reportLogger.LogClusterPolicyReport(&clusterReport)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #102

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
Instead of having a big log line containing all the content from the PolicyStore (which includes the `ClusterPolicyReport` and all the namespaced `PolicyReports`), this commit creates a `PolicyReportLogger` which logs all the relevant information per scanned resource.

## Test

I didn't create any tests for this class because it's just responsible for logging. However, I did test this manually by running:
```
./bin/audit-scanner --store memory --policy-server-url "https://localhost:8443" --insecure-ssl --output-scan
```

eg.:
```
{"level":"info","dict":{"policy":"cap-service-external-ip","rule":"service-external-ip","result":"pass","message":"","resource_api_version":"v1","resource_kind":"Service","resource_namespace":"some-namespace","resource_name":"some-pod","resource_version":"780797213"},"time":"2023-12-20T15:20:58Z"}

{"level":"info","dict":{"policy":"cap-pod-disruption-budget","rule":"pod-disruption-budget","result":"fail","message":"minAvailable isn't allowed in a PDB","resource_api_version":"policy/v1","resource_kind":"PodDisruptionBudget","resource_namespace":"some-namespace","resource_name":"some-pod","resource_version":"438425862"},"time":"2023-12-20T15:20:58Z"}
```


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
I've added the fields from `(Cluster)PolicyReports` that we need but happy to iterate this PR to include more information that you also find relevant!