### PR TITLE
fix: Correctly skip unexistent resources 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/kubewarden/kubewarden-controller v1.9.0
 	github.com/rs/zerolog v1.31.0
 	github.com/spf13/cobra v1.8.0
-	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
@@ -52,6 +51,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -476,14 +476,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
-golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
-golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 h1:qCEDpW1G+vcj3Y7Fy52pEM1AWm3abj8WimGYejI3SC4=
-golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
-golang.org/x/exp v0.0.0-20231219180239-dc181d75b848 h1:+iq7lrkxmFNBM7xx+Rae2W6uyPfhPeDWD+n+JgppptE=
-golang.org/x/exp v0.0.0-20231219180239-dc181d75b848/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc h1:ao2WRsKSzW6KuUY9IWPwWahcHCgR0s52IfwutMfEbdM=
 golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/internal/policies/filter_test.go
+++ b/internal/policies/filter_test.go
@@ -45,6 +45,23 @@ func TestFilterAuditablePolicies(t *testing.T) {
 		},
 		Status: policiesv1.PolicyStatus{PolicyStatus: policiesv1.PolicyStatusActive},
 	}
+	hasAllResourcesOperations := policiesv1.AdmissionPolicy{
+		Spec: policiesv1.AdmissionPolicySpec{
+			PolicySpec: policiesv1.PolicySpec{
+				BackgroundAudit: true,
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{"*"},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"*"},
+						APIVersions: []string{"*"},
+						Resources:   []string{"*"},
+						Scope:       nil,
+					},
+				}},
+			},
+		},
+		Status: policiesv1.PolicyStatus{PolicyStatus: policiesv1.PolicyStatusActive},
+	}
 	auditable := policiesv1.AdmissionPolicy{
 		Spec: policiesv1.AdmissionPolicySpec{
 			PolicySpec: policiesv1.PolicySpec{
@@ -72,6 +89,7 @@ func TestFilterAuditablePolicies(t *testing.T) {
 		{"policy not active", []policiesv1.Policy{&pending}, []policiesv1.Policy{}},
 		{"policy without create operation", []policiesv1.Policy{&noCreate}, []policiesv1.Policy{}},
 		{"policy with all resources (*)", []policiesv1.Policy{&hasAllResources}, []policiesv1.Policy{}},
+		{"policy with all resources and operations (*)", []policiesv1.Policy{&hasAllResourcesOperations}, []policiesv1.Policy{}},
 		{"auditable policy", []policiesv1.Policy{&auditable}, []policiesv1.Policy{&auditable}},
 		{"auditable policy with all the others policies", []policiesv1.Policy{&auditable, &noBackgroundAudit, &noCreate, &pending, &hasAllResources}, []policiesv1.Policy{&auditable}},
 		{"empty array", []policiesv1.Policy{}, []policiesv1.Policy{}},

--- a/internal/resources/fetcher.go
+++ b/internal/resources/fetcher.go
@@ -2,11 +2,9 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
-	"github.com/kubewarden/audit-scanner/internal/constants"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -73,7 +71,7 @@ func (f *Fetcher) GetResourcesForPolicies(ctx context.Context, policies []polici
 	for resourceFilter, policies := range gvrMap {
 		isNamespaced, err := f.isNamespacedResource(resourceFilter.groupVersionResource)
 		if err != nil {
-			if errors.Is(err, constants.ErrResourceNotFound) {
+			if apimachineryerrors.IsNotFound(err) {
 				log.Warn().
 					Str("resource GVK", resourceFilter.groupVersionResource.String()).
 					Msg("API resource not found")
@@ -133,7 +131,7 @@ func (f *Fetcher) isNamespacedResource(gvr schema.GroupVersionResource) (bool, e
 			return apiResource.Namespaced, nil
 		}
 	}
-	return false, constants.ErrResourceNotFound
+	return false, apimachineryerrors.NewNotFound(gvr.GroupResource(), gvr.Resource)
 }
 
 // GetClusterWideResourcesForPolicies fetches all cluster wide resources that must be
@@ -150,7 +148,7 @@ func (f *Fetcher) GetClusterWideResourcesForPolicies(ctx context.Context, polici
 	for resourceFilter, policies := range gvrMap {
 		isNamespaced, err := f.isNamespacedResource(resourceFilter.groupVersionResource)
 		if err != nil {
-			if errors.Is(err, constants.ErrResourceNotFound) {
+			if apimachineryerrors.IsNotFound(err) {
 				log.Warn().
 					Str("resource GVK", resourceFilter.groupVersionResource.String()).
 					Msg("API resource not found")

--- a/internal/resources/fetcher_test.go
+++ b/internal/resources/fetcher_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kubewarden/audit-scanner/internal/constants"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -767,7 +766,12 @@ func TestIsNamespacedResource(t *testing.T) {
 				Version:  "v1",
 				Resource: "foos",
 			},
-			false, constants.ErrResourceNotFound,
+			false,
+			apimachineryerrors.NewNotFound(
+				schema.GroupResource{
+					Group:    "",
+					Resource: "foos",
+				}, "foos"),
 		},
 	}
 
@@ -782,7 +786,7 @@ func TestIsNamespacedResource(t *testing.T) {
 			fetcher := Fetcher{dynamicClient, "", "", fakeClientSet}
 
 			isNamespaced, err := fetcher.isNamespacedResource(ttest.gvr)
-			if (err != nil && ttest.expectedErr != nil && !errors.Is(err, ttest.expectedErr)) || (err != nil && ttest.expectedErr == nil) {
+			if (err != nil && ttest.expectedErr != nil && err.Error() != ttest.expectedErr.Error()) || (err != nil && ttest.expectedErr == nil) {
 				t.Errorf("unexpected error: " + err.Error())
 			}
 			if isNamespaced != ttest.expectedIsNamespaced {


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/168

When building the corpus of resources that match the policy rules,
correctly skip those that are unexistent (e.g: "*/v1").

Emit a warning instead. The scan will still process the correct resources that match the provided GVR. Example:


```
{"level":"info","time":"2024-01-08T14:49:26+01:00","message":"querying PolicyServers at https://localhost:3000 for debugging purposes. Don't forget to start `kubectl port-forward` if needed"}
{"level":"warn","time":"2024-01-08T14:49:26+01:00","message":"connecting to PolicyServers endpoints without validating TLS connection"}
{"level":"info","namespace":"default","time":"2024-01-08T14:49:26+01:00","message":"namespace scan started"}
{"level":"info","namespace":"default","dict":{"policies to evaluate":6,"policies skipped":0},"time":"2024-01-08T14:49:26+01:00","message":"policy count"}
new warn instead of error and stop -> {"level":"warn","resource GVK":"*/v1, Resource=pods","time":"2024-01-08T14:49:26+01:00","message":"API resource not found"}
{"level":"debug","dict":{"report name":"polr-ns-default","report ns":"default","report resourceVersion":"12261"},"time":"2024-01-08T14:49:26+01:00","message":"PolicyReport found"}
{"level":"debug","skip-evaluation":{"policy":"do-not-run-as-root","policyResourceVersion":"1181","policyUID":"50b114f4-e35c-4867-bf44-f36d2b2c17de","resource":"nginx-privileged","resourceResourceVersion":"12017"},"time":"2024-01-08T14:49:26+01:00","message":"Previous result found. Reusing result"}
{"level":"debug","skip-evaluation":{"policy":"do-not-share-host-paths","policyResourceVersion":"1168","policyUID":"d6c24ec7-d1e6-43c8-b41d-c791e72c20e9","resource":"nginx-privileged","resourceResourceVersion":"12017"},"time":"2024-01-08T14:49:26+01:00","message":"Previous result found. Reusing result"}
{"level":"debug","skip-evaluation":{"policy":"drop-capabilities","policyResourceVersion":"1175","policyUID":"92e4e649-2773-418b-9c23-7d3784f1e593","resource":"nginx-privileged","resourceResourceVersion":"12017"},"time":"2024-01-08T14:49:26+01:00","message":"Previous result found. Reusing result"}
{"level":"debug","skip-evaluation":{"policy":"no-host-namespace-sharing","policyResourceVersion":"1171","policyUID":"e01f8744-06db-4833-9b75-6d124465455c","resource":"nginx-privileged","resourceResourceVersion":"12017"},"time":"2024-01-08T14:49:26+01:00","message":"Previous result found. Reusing result"}
{"level":"debug","skip-evaluation":{"policy":"no-privilege-escalation","policyResourceVersion":"1150","policyUID":"9ccfdb51-be63-4073-9581-656eb8503a31","resource":"nginx-privileged","resourceResourceVersion":"12017"},"time":"2024-01-08T14:49:26+01:00","message":"Previous result found. Reusing result"}
{"level":"debug","response":{"uid":"3c8e1589-708e-41f9-9b2e-5f73325a1498","policy":"no-privileged-pod","resource":"nginx-privileged","allowed":false},"time":"2024-01-08T14:49:26+01:00","message":"audit review response"}
{"level":"debug","report name":"polr-ns-default","result":{"policy":"no-privileged-pod","resource":"nginx-privileged","allowed":false,"result":"fail"},"time":"2024-01-08T14:49:26+01:00","message":"added result to report"}
{"level":"debug","dict":{"report name":"polr-ns-default","report ns":"default","report resourceVersion":"12261"},"time":"2024-01-08T14:49:26+01:00","message":"PolicyReport found"}
{"level":"debug","dict":{"report name":"polr-ns-default","report ns":"default","report resourceVersion":"12261"},"time":"2024-01-08T14:49:26+01:00","message":"PolicyReport found"}
{"level":"debug","dict":{"report name":"polr-ns-default","report ns":"default","report resourceVersion":"12402","summary":"{\"pass\":5,\"fail\":1,\"warn\":0,\"error\":0,\"skip\":0}"},"time":"2024-01-08T14:49:26+01:00","message":"updated PolicyReport"}
{"level":"info","namespace":"default","time":"2024-01-08T14:49:26+01:00","message":"namespace scan finished"}
note that there's 1 fail as there should be
```


Add relevant unit tests.



<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added a relevant unit test to `resources/fetcher_test.go`, added adjacent test to `policies/fetcher_test.go`

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
