### PR TITLE
fix: set content-type to application/json when calling the policy-server

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -360,6 +360,8 @@ func sendAdmissionReviewToPolicyServer(url *url.URL, admissionRequest *admv1.Adm
 	}
 
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, url.String(), bytes.NewBuffer(payload))
+	req.Header.Add("Content-Type", "application/json")
+
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -369,9 +371,10 @@ func sendAdmissionReviewToPolicyServer(url *url.URL, admissionRequest *admv1.Adm
 	if err != nil {
 		return nil, fmt.Errorf("cannot read body of response: %w", err)
 	}
-	if res.StatusCode > 299 {
-		return nil, fmt.Errorf("response failed with status code: %d and\nbody: %s", res.StatusCode, body)
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d body: %s", res.StatusCode, body)
 	}
+
 	admissionReview := admv1.AdmissionReview{}
 	err = json.Unmarshal(body, &admissionReview)
 	if err != nil {


### PR DESCRIPTION
## Description
Set the content type to `application/json` when calling the policy server.
The API now is checking the content type, if not set this will result in a 415 error.
Also, check that the status code is 200 instead of `< 299`
## Test

tested with e2e tests and unit tests are passing