### PR TITLE
ci: Enable codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           go-version: "1.21"
       - run: make unit-tests
+      - name: Upload unit-tests coverage to Codecov
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        with:
+          name: unit-tests
+          directory: coverage/unit-tests
+          flags: unit-tests
+          verbose: true
 
   golangci:
     name: Golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint: $(GOLANGCI_LINT)
 
 .PHONY: unit-tests
 unit-tests: fmt vet ## Run unit tests.
-	go test ./cmd/... ./internal/... -test.v -coverprofile cover.out
+	go test ./cmd/... ./internal/... -race -test.v -coverprofile=coverage/unit-tests/coverage.txt -covermode=atomic
 
 build: fmt vet lint ## Build audit-scanner binary.
 	go build -o bin/audit-scanner .

--- a/coverage/unit-tests/.gitignore
+++ b/coverage/unit-tests/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/187

- Change `make unit-tests` to save coverage files.
- Create new `coverage/unit-tests/` folder.
- Add codecov upload step to ci.yml. It uploads the coverage files resulting from running `make unit-tests`. Needs `CODECOV_ORG_TOKEN`, already set up.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI, PR should get a "welcome to codecov" message, and audit-scanner appear under https://app.codecov.io/github/kubewarden/.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
