### PR TITLE
fix(report): Result field is optional.

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -132,7 +132,11 @@ func newPolicyReportResult(policy policiesv1.Policy, admissionReview *admissionv
 	}
 
 	var message string
-	if !errored {
+	// We need to check if Result is not nil because this field is
+	// optional. If the policy returns "allowed" to the admissionReview,
+	// the Result field is not checked by Kubernetes.
+	// https://pkg.go.dev/k8s.io/api@v0.29.2/admission/v1#AdmissionResponse
+	if !errored && admissionReview.Response.Result != nil {
 		message = admissionReview.Response.Result.Message
 	}
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -235,6 +235,46 @@ func TestNewPolicyReportResult(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Validating policy, allowed response with no message",
+			policy: &policiesv1.ClusterAdmissionPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:             "policy-uid",
+					ResourceVersion: "1",
+					Name:            "policy-name",
+					Annotations: map[string]string{
+						policiesv1.AnnotationSeverity: severityLow,
+					},
+				},
+				Spec: policiesv1.ClusterAdmissionPolicySpec{
+					PolicySpec: policiesv1.PolicySpec{
+						Mutating: false,
+					},
+				},
+			},
+			amissionReview: &admissionv1.AdmissionReview{
+				Response: &admissionv1.AdmissionResponse{
+					Allowed: true,
+					Result:  nil,
+				},
+			},
+			errored: false,
+			expectedResult: &wgpolicy.PolicyReportResult{
+				Source:          policyReportSource,
+				Policy:          "clusterwide-policy-name",
+				Severity:        severityLow,
+				Result:          statusPass,
+				Timestamp:       now,
+				Scored:          true,
+				SubjectSelector: &metav1.LabelSelector{},
+				Description:     "",
+				Properties: map[string]string{
+					PropertyPolicyUID:             "policy-uid",
+					propertyPolicyResourceVersion: "1",
+					typeValidating:                valueTypeTrue,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -137,7 +137,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			amissionReview: &admissionv1.AdmissionReview{
 				Response: &admissionv1.AdmissionResponse{
 					Allowed: true,
-					Result:  &metav1.Status{Message: "The request was allowed"},
+					Result:  nil,
 				},
 			},
 			errored: false,
@@ -149,7 +149,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 				Timestamp:       now,
 				Scored:          true,
 				SubjectSelector: &metav1.LabelSelector{},
-				Description:     "The request was allowed",
+				Description:     "",
 				Properties: map[string]string{
 					PropertyPolicyUID:             "policy-uid",
 					propertyPolicyResourceVersion: "1",
@@ -224,46 +224,6 @@ func TestNewPolicyReportResult(t *testing.T) {
 				Policy:          "namespaced-policy-namespace-policy-name",
 				Severity:        severityInfo,
 				Result:          statusError,
-				Timestamp:       now,
-				Scored:          true,
-				SubjectSelector: &metav1.LabelSelector{},
-				Description:     "",
-				Properties: map[string]string{
-					PropertyPolicyUID:             "policy-uid",
-					propertyPolicyResourceVersion: "1",
-					typeValidating:                valueTypeTrue,
-				},
-			},
-		},
-		{
-			name: "Validating policy, allowed response with no message",
-			policy: &policiesv1.ClusterAdmissionPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					UID:             "policy-uid",
-					ResourceVersion: "1",
-					Name:            "policy-name",
-					Annotations: map[string]string{
-						policiesv1.AnnotationSeverity: severityLow,
-					},
-				},
-				Spec: policiesv1.ClusterAdmissionPolicySpec{
-					PolicySpec: policiesv1.PolicySpec{
-						Mutating: false,
-					},
-				},
-			},
-			amissionReview: &admissionv1.AdmissionReview{
-				Response: &admissionv1.AdmissionResponse{
-					Allowed: true,
-					Result:  nil,
-				},
-			},
-			errored: false,
-			expectedResult: &wgpolicy.PolicyReportResult{
-				Source:          policyReportSource,
-				Policy:          "clusterwide-policy-name",
-				Severity:        severityLow,
-				Result:          statusPass,
 				Timestamp:       now,
 				Scored:          true,
 				SubjectSelector: &metav1.LabelSelector{},

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -33,9 +33,7 @@ func newMockPolicyServer() *httptest.Server {
 		admissionReview := admissionv1.AdmissionReview{
 			Response: &admissionv1.AdmissionResponse{
 				Allowed: true,
-				Result: &metav1.Status{
-					Message: "The request was allowed",
-				},
+				Result:  nil,
 			},
 		}
 		response, err := json.Marshal(admissionReview)


### PR DESCRIPTION
## Description

The code which builds the PolicyReportResult does check if the Result field from the AdmissionRespose type is nil. Causing a nil pointer dereference. This field is optional and it can be nil. Specially if the policy result is "allowed" where there is not further details about the result of the evaluation.

This commit fixes this issue by checking if the Result field has something before trying to get the possible error message from the policy.


Fix #212 

## Test

I've added a new unit test to cover this bug.

```shell
make unit-tests
```

