### PR TITLE
feat: add resource-based reports cache 

### DIFF
--- a/internal/report/constants.go
+++ b/internal/report/constants.go
@@ -3,7 +3,7 @@ package report
 const (
 	policyReportSource            = "kubewarden"
 	propertyPolicyResourceVersion = "policy-resource-version"
-	PropertyPolicyUID             = "policy-uid"
+	propertyPolicyUID             = "policy-uid"
 )
 
 const (


### PR DESCRIPTION
## Description

Fix #194 

This PR adds back the  re-use of policy report results, if the resource and the policy were not changed from the previous audit, so that we avoid hitting the policy server to get the same result.


## Test

Unit tests have been added.

## Additional Information
