### PR TITLE
fix: Provide uniquely parsable policy name in results

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -181,7 +181,7 @@ func newPolicyReportResult(policy policiesv1.Policy, admissionReview *admissionv
 		Source:          policyReportSource,
 		Policy:          getParsablePolicyName(policy), // {cap_,ap_<ns name>}_<policy name>
 		Category:        category,
-		Severity:        computePolicyResultSeverity(policy),           // either info for monitor or empty
+		Severity:        computePolicyResultSeverity(policy),           // either info for monitor or policy's severity
 		Timestamp:       timestamp,                                     // time the result was computed
 		Result:          computePolicyResult(errored, admissionReview), // pass, fail, error
 		Scored:          true,

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubewarden/audit-scanner/internal/constants"
 	policiesv1 "github.com/kubewarden/kubewarden-controller/pkg/apis/policies/v1"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -128,6 +129,10 @@ func TestNewPolicyReportResult(t *testing.T) {
 						policiesv1.AnnotationSeverity: severityLow,
 					},
 				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       constants.KubewardenKindClusterAdmissionPolicy,
+					APIVersion: constants.KubewardenPoliciesGroup + "/" + constants.KubewardenPoliciesVersion,
+				},
 				Spec: policiesv1.ClusterAdmissionPolicySpec{
 					PolicySpec: policiesv1.PolicySpec{
 						Mutating: false,
@@ -143,7 +148,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			errored: false,
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
-				Policy:          "clusterwide-policy-name",
+				Policy:          "cap_policy-name",
 				Severity:        severityLow,
 				Result:          statusPass,
 				Timestamp:       now,
@@ -169,6 +174,10 @@ func TestNewPolicyReportResult(t *testing.T) {
 						policiesv1.AnnotationSeverity: severityCritical,
 					},
 				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       constants.KubewardenKindAdmissionPolicy,
+					APIVersion: constants.KubewardenPoliciesGroup + "/" + constants.KubewardenPoliciesVersion,
+				},
 				Spec: policiesv1.AdmissionPolicySpec{
 					PolicySpec: policiesv1.PolicySpec{
 						Mutating: true,
@@ -184,7 +193,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			errored: false,
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
-				Policy:          "namespaced-policy-namespace-policy-name",
+				Policy:          "ap_policy-namespace_policy-name",
 				Severity:        severityCritical,
 				Result:          statusFail,
 				Timestamp:       now,
@@ -210,6 +219,10 @@ func TestNewPolicyReportResult(t *testing.T) {
 						policiesv1.AnnotationSeverity: severityInfo,
 					},
 				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       constants.KubewardenKindAdmissionPolicy,
+					APIVersion: constants.KubewardenPoliciesGroup + "/" + constants.KubewardenPoliciesVersion,
+				},
 				Spec: policiesv1.AdmissionPolicySpec{
 					PolicySpec: policiesv1.PolicySpec{
 						Mutating: false,
@@ -221,7 +234,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			errored:        true,
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
-				Policy:          "namespaced-policy-namespace-policy-name",
+				Policy:          "ap_policy-namespace_policy-name",
 				Severity:        severityInfo,
 				Result:          statusError,
 				Timestamp:       now,

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -112,11 +112,11 @@ func TestNewPolicyReportResult(t *testing.T) {
 	now := metav1.Timestamp{Seconds: time.Now().Unix()}
 
 	tests := []struct {
-		name           string
-		policy         policiesv1.Policy
-		amissionReview *admissionv1.AdmissionReview
-		errored        bool
-		expectedResult *wgpolicy.PolicyReportResult
+		name            string
+		policy          policiesv1.Policy
+		admissionReview *admissionv1.AdmissionReview
+		errored         bool
+		expectedResult  *wgpolicy.PolicyReportResult
 	}{
 		{
 			name: "Validating policy, allowed response",
@@ -139,7 +139,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 					},
 				},
 			},
-			amissionReview: &admissionv1.AdmissionReview{
+			admissionReview: &admissionv1.AdmissionReview{
 				Response: &admissionv1.AdmissionResponse{
 					Allowed: true,
 					Result:  nil,
@@ -184,7 +184,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 					},
 				},
 			},
-			amissionReview: &admissionv1.AdmissionReview{
+			admissionReview: &admissionv1.AdmissionReview{
 				Response: &admissionv1.AdmissionResponse{
 					Allowed: false,
 					Result:  &metav1.Status{Message: "The request was rejected"},
@@ -230,8 +230,8 @@ func TestNewPolicyReportResult(t *testing.T) {
 					},
 				},
 			},
-			amissionReview: nil,
-			errored:        true,
+			admissionReview: nil,
+			errored:         true,
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
 				Policy:          "ap_policy-namespace_policy-name",
@@ -252,7 +252,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := newPolicyReportResult(test.policy, test.amissionReview, test.errored, now)
+			result := newPolicyReportResult(test.policy, test.admissionReview, test.errored, now)
 			assert.Equal(t, test.expectedResult, result)
 		})
 	}


### PR DESCRIPTION
## Description

With 1.11, we have
- correctly moved from saving `PolicyReportResult.Rule == policy.metadata.name`  to empty.
- set `PolicyReportResult.Policy` to the `clusterwide-policyname`, `namespaced-policyname`. Yet this is not parseable, as namespace names can contain `-`, hence not knowing when the prefix ends (e.g: `namespaced-my-pretty-ns-foo-policyname`).

This is a problem because consumers can't easily find the policy and link between the PolicyReportResult and the policy. 

Example:

![Screenshot 2024-03-15 at 12 33 47](https://github.com/kubewarden/audit-scanner/assets/2196685/c1d6b507-7bf9-490a-ad7f-08bd892d8777)

Hence:

Set `PolicyReportResult.Policy` to 

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Unit tests.


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

1. Use `PolicyReportRule` as 1.10:
```diff
diff --git a/internal/report/report.go b/internal/report/report.go
index a6cf637..4aa8fe3 100644
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -142,9 +142,10 @@ func newPolicyReportResult(policy policiesv1.Policy, admissionReview *admissionv
 
 	return &wgpolicy.PolicyReportResult{
 		Source:          policyReportSource,
-		Policy:          policy.GetUniqueName(),
+		Policy:          policy.GetUniqueName(), // {clusterwide,namespaced-<ns name>}-<policy name>
+		Rule:            policy.GetName(),       // policy.metadata.name
 		Category:        category,
-		Severity:        computePolicyResultSeverity(policy),           // either info for monitor or empty
+		Severity:        computePolicyResultSeverity(policy),           // either info for monitor or the policy's severity
 		Timestamp:       timestamp,                                     // time the result was computed
 		Result:          computePolicyResult(errored, admissionReview), // pass, fail, error
 		Scored:          true,
diff --git a/internal/report/report_test.go b/internal/report/report_test.go
index 4e831f3..1b8fb77 100644
--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -144,6 +144,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
 				Policy:          "clusterwide-policy-name",
+				Rule:            "policy-name",
 				Severity:        severityLow,
 				Result:          statusPass,
 				Timestamp:       now,
@@ -185,6 +186,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
 				Policy:          "namespaced-policy-namespace-policy-name",
+				Rule:            "policy-name",
 				Severity:        severityCritical,
 				Result:          statusFail,
 				Timestamp:       now,
@@ -222,6 +224,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 			expectedResult: &wgpolicy.PolicyReportResult{
 				Source:          policyReportSource,
 				Policy:          "namespaced-policy-namespace-policy-name",
+				Rule:            "policy-name",
 				Severity:        severityInfo,
 				Result:          statusError,
 				Timestamp:       now,

```
2. Lobby for a v1beta2 policy that includes a Reference to the Policy itself.