### PR TITLE
fix: add policy name and policy namespace to result properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ results:
     properties:
       policy-resource-version: "2684810"
       policy-uid: 826dd4ef-9db5-408e-9482-455f278bf9bf
+      policy-name: safe-labels
       validating: "true"
     resourceSelector: {}
     result: fail

--- a/internal/report/constants.go
+++ b/internal/report/constants.go
@@ -4,6 +4,8 @@ const (
 	policyReportSource            = "kubewarden"
 	propertyPolicyResourceVersion = "policy-resource-version"
 	propertyPolicyUID             = "policy-uid"
+	propertyPolicyName            = "policy-name"
+	propertyPolicyNamespace       = "policy-namespace"
 )
 
 const (

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -195,6 +195,10 @@ func computeProperties(policy policiesv1.Policy) map[string]string {
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
 	properties[propertyPolicyResourceVersion] = policy.GetResourceVersion()
 	properties[propertyPolicyUID] = string(policy.GetUID())
+	properties[propertyPolicyName] = policy.GetName()
+	if policy.GetNamespace() != "" {
+		properties[propertyPolicyNamespace] = policy.GetNamespace()
+	}
 
 	return properties
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -153,6 +153,7 @@ func TestNewPolicyReportResult(t *testing.T) {
 				Properties: map[string]string{
 					propertyPolicyUID:             "policy-uid",
 					propertyPolicyResourceVersion: "1",
+					propertyPolicyName:            "policy-name",
 					typeValidating:                valueTypeTrue,
 				},
 			},
@@ -194,6 +195,8 @@ func TestNewPolicyReportResult(t *testing.T) {
 				Properties: map[string]string{
 					propertyPolicyUID:             "policy-uid",
 					propertyPolicyResourceVersion: "1",
+					propertyPolicyName:            "policy-name",
+					propertyPolicyNamespace:       "policy-namespace",
 					typeMutating:                  valueTypeTrue,
 				},
 			},
@@ -231,6 +234,8 @@ func TestNewPolicyReportResult(t *testing.T) {
 				Properties: map[string]string{
 					propertyPolicyUID:             "policy-uid",
 					propertyPolicyResourceVersion: "1",
+					propertyPolicyName:            "policy-name",
+					propertyPolicyNamespace:       "policy-namespace",
 					typeValidating:                valueTypeTrue,
 				},
 			},


### PR DESCRIPTION
## Description

Adds the policy name and the policy namespace (if any) to result properties