### PR TITLE
feat: Add new `kubewarden.io/policyreport-version: v2` label

### DIFF
--- a/internal/report/constants.go
+++ b/internal/report/constants.go
@@ -35,6 +35,8 @@ const (
 )
 
 const (
-	labelAppManagedBy = "app.kubernetes.io/managed-by"
-	labelApp          = "kubewarden"
+	labelAppManagedBy             = "app.kubernetes.io/managed-by"
+	labelApp                      = "kubewarden"
+	labelPolicyReportVersion      = "kubewarden.io/policyreport-version"
+	labelPolicyReportVersionValue = "v2"
 )

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -18,7 +18,8 @@ func NewPolicyReport(resource unstructured.Unstructured) *wgpolicy.PolicyReport 
 			Name:      string(resource.GetUID()),
 			Namespace: resource.GetNamespace(),
 			Labels: map[string]string{
-				labelAppManagedBy: labelApp,
+				labelAppManagedBy:        labelApp,
+				labelPolicyReportVersion: labelPolicyReportVersionValue,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -75,7 +76,8 @@ func NewClusterPolicyReport(resource unstructured.Unstructured) *wgpolicy.Cluste
 		ObjectMeta: metav1.ObjectMeta{
 			Name: string(resource.GetUID()),
 			Labels: map[string]string{
-				labelAppManagedBy: labelApp,
+				labelAppManagedBy:        labelApp,
+				labelPolicyReportVersion: labelPolicyReportVersionValue,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -27,6 +27,7 @@ func TestNewPolicyReport(t *testing.T) {
 	assert.Equal(t, "uid", policyReport.ObjectMeta.Name)
 	assert.Equal(t, "namespace", policyReport.ObjectMeta.Namespace)
 	assert.Equal(t, "kubewarden", policyReport.ObjectMeta.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "v2", policyReport.ObjectMeta.Labels["kubewarden.io/policyreport-version"])
 
 	assert.Equal(t, "v1", policyReport.ObjectMeta.OwnerReferences[0].APIVersion)
 	assert.Equal(t, "Pod", policyReport.ObjectMeta.OwnerReferences[0].Kind)
@@ -73,6 +74,7 @@ func TestNewClusterPolicyReport(t *testing.T) {
 
 	assert.Equal(t, "uid", clusterPolicyReport.ObjectMeta.Name)
 	assert.Equal(t, "kubewarden", clusterPolicyReport.ObjectMeta.Labels[labelAppManagedBy])
+	assert.Equal(t, "v2", clusterPolicyReport.ObjectMeta.Labels["kubewarden.io/policyreport-version"])
 
 	assert.Equal(t, "v1", clusterPolicyReport.ObjectMeta.OwnerReferences[0].APIVersion)
 	assert.Equal(t, "Namespace", clusterPolicyReport.ObjectMeta.OwnerReferences[0].Kind)


### PR DESCRIPTION

## Description

This allows us to discriminiate policyreports between pre 1.11 (missing label), and 1.11 (having label), plus helping for future changes.

Relates to  https://github.com/kubewarden/helm-charts/issues/408

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
