### PR TITLE
deps: Bump golang to 1.22 in Dockerfile builder layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the audit-scanner binary
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Consuming `github.com/kubewarden/kubewarden-controller v1.12.0` brings a bump to Go 1.22 just as it is in the controller.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

This is needed to build releases.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
