### PR TITLE
parallelize everything

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,28 +25,25 @@ The map would look like this:
 namespaced resources.
 
 The code then starts to iterate over the keys of the map, hence over the types of cluster-wide Kubernetes resources that are targeted by the policies. This is done
-[here](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/scanner/scanner.go#L223).
+inside of the `ScanClusterWideResources` method of `Scanner`.
 The code will get all the resources of that type. The resources are fetched with pagination to reduce the memory usage and the load on the Kuberentes API server.
 
 > Note: the order by which the keys are iterated is not deterministic.
 
-The code processes each chunk of resources, and for each resource it invokes the [`auditClusterResource`](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/scanner/scanner.go#L246)
-method.
+The code processes each chunk of resources, and for each resource it invokes the `auditClusterResource` method of `Scanner`.
 
 > **Important:** this portion of the code is parallelized
 >
 > For example, assuming the code is auditing the `Namespace` resource kind, and there are 20k namespaces in the cluster,
-> the pool of workers will evaluate `100` namespaces in parallel. The size of the worker pool is currently hard coded to
-> [`here`](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/scanner/scanner.go#L32).
+> the pool of workers will evaluate `100` namespaces in parallel. The size of the worker pool is configured with the `--parallel-resources` flag.
 
-The [`auditClusterResource`](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/scanner/scanner.go#L325) function
-takes as input a Kubernetes resource (e.g.: a specific `Namespace` object) and all the policies that target that kind of resource (e.g.: kubernetes `Namespace` objects).
+The `auditClusterResource` function takes as input a Kubernetes resource (e.g.: a specific `Namespace` object) and all the policies that target that kind of resource (e.g.: kubernetes `Namespace` objects).
 The code then iterates over the list of policies and, for each one performs the following actions:
 
 - Skip the policy if it doesn't target the specific object. This could happen because of labels selectors set on the policy
 - Create a fake `CREATE` admission request object for that resource, send it to the Policy Server that hosts the policy, and get the response
 
-> **Note:** this part of the code is not concurrent. Each policy is evaulated sequentially, one at a time. This is something that could be improved in the future.
+> **Important:** this portion of the code is parallelized. The number of parallel policies to be evaluated is configured with the `--parallel-policies` flag.
 
 Once all the policies interested about the specific Kubernetes object have been processed, a `ClusterPolicyReport` object is created.
 Depending on how the `audit-scanner` process was started, the `ClusterPolicyReport` object is either written into etcd or is printed on the standard output.
@@ -54,17 +51,17 @@ Depending on how the `audit-scanner` process was started, the `ClusterPolicyRepo
 ### Scanning namespaced resources
 
 The code starts by getting a list of all the `Namespace` objects in the cluster, except the ones manually excluded by the user.
-See [here](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/scanner/scanner.go#L183).
+This is done inside of the `ScanAllNamespaces` method of `Scanner`.
 
-For each namespace, the code invokes the [`ScanNamespace`](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/scanner/scanner.go#L120)
-method.
+For each namespace, the code invokes the `ScanNamespace` method.
 
-> **Note:** this part of the code is not concurrent. Each Namespace is evaluated sequentially. This is something that could be improved in the future.
+> **Important:** this portion of the code is parallelized. The number of parallel policies to be evaluated is configured with the `--parallel-namespaces` flag.
 
-The code uses the [`GetPoliciesForANamespace`](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/policies/client.go#L61) method
+The code uses the `GetPoliciesForANamespace` method
 to build a map with the Kubernetes resource as key, and the policies targeting that resource as value.
 This map is similar to the one created for the cluster-wide resources. However, in this case the types of policies associated with a Kubernetes
 resource could be both `ClusterAdmissionPolicy` and `NamespaceAdmissionPolicy`.
 
 The code then iterates over the keys of the map, hence over the types of namespaced Kubernetes resources that are targeted by the policies. This is done exactly like
-with when evaluating the cluster-wide resources. See [here](https://github.com/kubewarden/audit-scanner/blob/038da594f989f97420bf235979ae1e60335303e6/internal/scanner/scanner.go#L140-L170).
+with when evaluating the cluster-wide resources.
+This is done inside of the `ScanNamespace` method of `Scanner`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,10 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 		if err != nil {
 			return err
 		}
+		pageSize, err := cmd.Flags().GetInt("page-size")
+		if err != nil {
+			return err
+		}
 
 		config := ctrl.GetConfigOrDie()
 		dynamicClient := dynamic.NewForConfigOrDie(config)
@@ -95,7 +99,7 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 		if err != nil {
 			return err
 		}
-		k8sClient, err := k8s.NewClient(dynamicClient, clientset, kubewardenNamespace, skippedNs)
+		k8sClient, err := k8s.NewClient(dynamicClient, clientset, kubewardenNamespace, skippedNs, int64(pageSize))
 		if err != nil {
 			return err
 		}
@@ -163,4 +167,5 @@ func init() {
 	rootCmd.Flags().IntP("parallel-namespaces", "", 1, "number of Namespaces to scan in parallel")
 	rootCmd.Flags().IntP("parallel-resources", "", 50, "number of resources to scan in parallel")
 	rootCmd.Flags().IntP("parallel-policies", "", 10, "number of policies to evaluate for a given resource in parallel")
+	rootCmd.Flags().IntP("page-size", "", 100, "number of resources to fetch from the Kubernetes API server when paginating")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,10 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 		if err != nil {
 			return err
 		}
+		parallelResourcesAudits, err := cmd.Flags().GetInt("parallel-resources")
+		if err != nil {
+			return err
+		}
 
 		config := ctrl.GetConfigOrDie()
 		dynamicClient := dynamic.NewForConfigOrDie(config)
@@ -89,7 +93,7 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 		}
 		policyReportStore := report.NewPolicyReportStore(client)
 
-		scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL, caCertFile)
+		scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL, caCertFile, parallelResourcesAudits)
 		if err != nil {
 			return err
 		}
@@ -145,4 +149,5 @@ func init() {
 	rootCmd.Flags().BoolVar(&insecureSSL, "insecure-ssl", false, "skip SSL cert validation when connecting to PolicyServers endpoints. Useful for development")
 	rootCmd.Flags().StringP("extra-ca", "f", "", "File path to CA cert in PEM format of PolicyServer endpoints")
 	rootCmd.Flags().BoolVar(&disableStore, "disable-store", false, "disable storing the results in the k8s cluster")
+	rootCmd.Flags().IntP("parallel-resources", "conc-res", 50, "number of resources to scan concurrently")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -165,7 +165,7 @@ func init() {
 	rootCmd.Flags().StringP("extra-ca", "f", "", "File path to CA cert in PEM format of PolicyServer endpoints")
 	rootCmd.Flags().BoolVar(&disableStore, "disable-store", false, "disable storing the results in the k8s cluster")
 	rootCmd.Flags().IntP("parallel-namespaces", "", 1, "number of Namespaces to scan in parallel")
-	rootCmd.Flags().IntP("parallel-resources", "", 50, "number of resources to scan in parallel")
-	rootCmd.Flags().IntP("parallel-policies", "", 10, "number of policies to evaluate for a given resource in parallel")
+	rootCmd.Flags().IntP("parallel-resources", "", 100, "number of resources to scan in parallel")
+	rootCmd.Flags().IntP("parallel-policies", "", 5, "number of policies to evaluate for a given resource in parallel")
 	rootCmd.Flags().IntP("page-size", "", 100, "number of resources to fetch from the Kubernetes API server when paginating")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,10 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 		if err != nil {
 			return err
 		}
+		parallelPoliciesAudit, err := cmd.Flags().GetInt("parallel-policies")
+		if err != nil {
+			return err
+		}
 
 		config := ctrl.GetConfigOrDie()
 		dynamicClient := dynamic.NewForConfigOrDie(config)
@@ -99,7 +103,8 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 
 		scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL, caCertFile,
 			parallelNamespacesAudits,
-			parallelResourcesAudits)
+			parallelResourcesAudits,
+			parallelPoliciesAudit)
 		if err != nil {
 			return err
 		}
@@ -155,6 +160,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&insecureSSL, "insecure-ssl", false, "skip SSL cert validation when connecting to PolicyServers endpoints. Useful for development")
 	rootCmd.Flags().StringP("extra-ca", "f", "", "File path to CA cert in PEM format of PolicyServer endpoints")
 	rootCmd.Flags().BoolVar(&disableStore, "disable-store", false, "disable storing the results in the k8s cluster")
-	rootCmd.Flags().IntP("parallel-namespaces", "parallel-namespaces", 1, "number of Namespaces to scan in parallel")
-	rootCmd.Flags().IntP("parallel-resources", "parallel-resources", 50, "number of resources to scan in parallel")
+	rootCmd.Flags().IntP("parallel-namespaces", "", 1, "number of Namespaces to scan in parallel")
+	rootCmd.Flags().IntP("parallel-resources", "", 50, "number of resources to scan in parallel")
+	rootCmd.Flags().IntP("parallel-policies", "", 10, "number of policies to evaluate for a given resource in parallel")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,10 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 		if err != nil {
 			return err
 		}
+		parallelNamespacesAudits, err := cmd.Flags().GetInt("parallel-namespaces")
+		if err != nil {
+			return err
+		}
 		parallelResourcesAudits, err := cmd.Flags().GetInt("parallel-resources")
 		if err != nil {
 			return err
@@ -93,7 +97,9 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 		}
 		policyReportStore := report.NewPolicyReportStore(client)
 
-		scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL, caCertFile, parallelResourcesAudits)
+		scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL, caCertFile,
+			parallelNamespacesAudits,
+			parallelResourcesAudits)
 		if err != nil {
 			return err
 		}
@@ -149,5 +155,6 @@ func init() {
 	rootCmd.Flags().BoolVar(&insecureSSL, "insecure-ssl", false, "skip SSL cert validation when connecting to PolicyServers endpoints. Useful for development")
 	rootCmd.Flags().StringP("extra-ca", "f", "", "File path to CA cert in PEM format of PolicyServer endpoints")
 	rootCmd.Flags().BoolVar(&disableStore, "disable-store", false, "disable storing the results in the k8s cluster")
-	rootCmd.Flags().IntP("parallel-resources", "conc-res", 50, "number of resources to scan concurrently")
+	rootCmd.Flags().IntP("parallel-namespaces", "parallel-namespaces", 1, "number of Namespaces to scan in parallel")
+	rootCmd.Flags().IntP("parallel-resources", "parallel-resources", 50, "number of resources to scan in parallel")
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -18,8 +18,6 @@ import (
 	"k8s.io/client-go/tools/pager"
 )
 
-const pageSize = 100
-
 // A client to get resources and namespaces from a Kubernetes cluster
 type Client struct {
 	// dynamicClient is used to get resource lists
@@ -28,16 +26,19 @@ type Client struct {
 	clientset kubernetes.Interface
 	// list of skipped namespaces from audit, by name. It includes kubewardenNamespace
 	skippedNs []string
+	// pageSize is the number of resources to fetch when paginating
+	pageSize int64
 }
 
 // NewClient returns a new client
-func NewClient(dynamicClient dynamic.Interface, clientset kubernetes.Interface, kubewardenNamespace string, skippedNs []string) (*Client, error) {
+func NewClient(dynamicClient dynamic.Interface, clientset kubernetes.Interface, kubewardenNamespace string, skippedNs []string, pageSize int64) (*Client, error) {
 	skippedNs = append(skippedNs, kubewardenNamespace)
 
 	return &Client{
 		dynamicClient,
 		clientset,
 		skippedNs,
+		pageSize,
 	}, nil
 }
 
@@ -70,7 +71,7 @@ func (f *Client) GetResources(gvr schema.GroupVersionResource, nsName string) (*
 		return resources, nil
 	})
 
-	listPager.PageSize = pageSize
+	listPager.PageSize = f.pageSize
 	return listPager, nil
 }
 

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+const pageSize = 100
+
 func TestGetResources(t *testing.T) {
 	var pods []runtime.Object
 	for i := 0; i < pageSize+5; i++ {
@@ -26,7 +28,7 @@ func TestGetResources(t *testing.T) {
 	dynamicClient := dynamicFake.NewSimpleDynamicClient(scheme.Scheme, pods...)
 	clientset := fake.NewSimpleClientset()
 
-	k8sClient, err := NewClient(dynamicClient, clientset, "kubewarden", nil)
+	k8sClient, err := NewClient(dynamicClient, clientset, "kubewarden", nil, pageSize)
 	require.NoError(t, err)
 
 	pager, err := k8sClient.GetResources(schema.GroupVersionResource{

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -251,7 +251,7 @@ func TestScanAllNamespaces(t *testing.T) {
 
 	policyReportStore := report.NewPolicyReportStore(client)
 
-	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "")
+	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", 10)
 	require.NoError(t, err)
 
 	runUID := uuid.New().String()
@@ -412,7 +412,7 @@ func TestScanClusterWideResources(t *testing.T) {
 
 	policyReportStore := report.NewPolicyReportStore(client)
 
-	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "")
+	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", 10)
 	require.NoError(t, err)
 
 	runUID := uuid.New().String()

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -30,6 +30,11 @@ import (
 	wgpolicy "sigs.k8s.io/wg-policy-prototypes/policy-report/pkg/api/wgpolicyk8s.io/v1alpha2"
 )
 
+const (
+	parallelNamespacesAudit = 1
+	parallelResourcesAudit  = 10
+)
+
 func newMockPolicyServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
@@ -251,7 +256,7 @@ func TestScanAllNamespaces(t *testing.T) {
 
 	policyReportStore := report.NewPolicyReportStore(client)
 
-	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", 10)
+	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", parallelNamespacesAudit, parallelResourcesAudit)
 	require.NoError(t, err)
 
 	runUID := uuid.New().String()
@@ -412,7 +417,7 @@ func TestScanClusterWideResources(t *testing.T) {
 
 	policyReportStore := report.NewPolicyReportStore(client)
 
-	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", 10)
+	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", parallelNamespacesAudit, parallelNamespacesAudit)
 	require.NoError(t, err)
 
 	runUID := uuid.New().String()

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	parallelNamespacesAudit = 1
-	parallelResourcesAudit  = 10
+	parallelNamespacesAudits = 1
+	parallelResourcesAudits  = 10
+	parallelPoliciesAudits   = 2
 )
 
 func newMockPolicyServer() *httptest.Server {
@@ -256,7 +257,7 @@ func TestScanAllNamespaces(t *testing.T) {
 
 	policyReportStore := report.NewPolicyReportStore(client)
 
-	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", parallelNamespacesAudit, parallelResourcesAudit)
+	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", parallelNamespacesAudits, parallelResourcesAudits, parallelPoliciesAudits)
 	require.NoError(t, err)
 
 	runUID := uuid.New().String()
@@ -417,7 +418,7 @@ func TestScanClusterWideResources(t *testing.T) {
 
 	policyReportStore := report.NewPolicyReportStore(client)
 
-	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", parallelNamespacesAudit, parallelNamespacesAudit)
+	scanner, err := NewScanner(policiesClient, k8sClient, policyReportStore, false, false, true, "", parallelNamespacesAudits, parallelNamespacesAudits, parallelPoliciesAudits)
 	require.NoError(t, err)
 
 	runUID := uuid.New().String()

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -34,6 +34,7 @@ const (
 	parallelNamespacesAudits = 1
 	parallelResourcesAudits  = 10
 	parallelPoliciesAudits   = 2
+	pageSize                 = 100
 )
 
 func newMockPolicyServer() *httptest.Server {
@@ -249,7 +250,7 @@ func TestScanAllNamespaces(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	k8sClient, err := k8s.NewClient(dynamicClient, clientset, "kubewarden", nil)
+	k8sClient, err := k8s.NewClient(dynamicClient, clientset, "kubewarden", nil, pageSize)
 	require.NoError(t, err)
 
 	policiesClient, err := policies.NewClient(client, "kubewarden", mockPolicyServer.URL)
@@ -410,7 +411,7 @@ func TestScanClusterWideResources(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	k8sClient, err := k8s.NewClient(dynamicClient, clientset, "kubewarden", nil)
+	k8sClient, err := k8s.NewClient(dynamicClient, clientset, "kubewarden", nil, pageSize)
 	require.NoError(t, err)
 
 	policiesClient, err := policies.NewClient(client, "kubewarden", mockPolicyServer.URL)


### PR DESCRIPTION
Change how the audit process is done, allowing more parallilazion if wanted by the user.

This PR adds these new flags (I'm open to change their names, I'm not super fond of them):

- `--parallel-namespaces`: how many Namespaces can be audited in parallel. Default is 1.
- `--parallel-resources`: how many resources can be audited in parallel. Default is 50.
- `--parallel-policies`: when auditing a specic resource, how many policies can be invoked in parallel. Default is 10.

By tuning these values, the user has direct control over how many HTTP requests are sent to the policy server(s) at the same time.
For example, `--parallel-namespaces 2 --parallel-resources 100 --parallel-policies 10` translates to a maximum of `2 * 100 * 10 = 2000` HTTP requests at the same time.

## Benchmarks

Given the following scenario:

- 30k RoleBinding objects, all defined inside of the `default` namespace
- 1 Policy Server, with 3 replicas
- 4 policies targeting RoleBinding objects

### No parallelization

```bash
audit-scanner --disable-store --parallel-namespaces 1 --parallel-policies 1 --parallel-resources 1
```

Leads to the following results:

```
User time (seconds): 77.85
System time (seconds): 43.11
Percent of CPU this job got: 29%
Elapsed (wall clock) time (h:mm:ss or m:ss): 6m 50.45s
Average shared text size (kbytes): 0
Average unshared data size (kbytes): 0
Average stack size (kbytes): 0
Average total size (kbytes): 0
Maximum resident set size (kbytes): 209872
Average resident set size (kbytes): 0
Major (requiring I/O) page faults: 0
Minor (reclaiming a frame) page faults: 10814
Voluntary context switches: 2569133
Involuntary context switches: 983543
Swaps: 0
File system inputs: 0
File system outputs: 0
Socket messages sent: 0
Socket messages received: 0
Signals delivered: 0
Page size (bytes): 4096
Exit status: 0
```

### Parallelization

```bash
./audit-scanner --disable-store --parallel-namespaces 2 --parallel-policies 10 --parallel-resources 100
```

Leads to the following results:

```
User time (seconds): 150.32
System time (seconds): 33.26
Percent of CPU this job got: 60%
Elapsed (wall clock) time (h:mm:ss or m:ss): 5m 3.90s
Average shared text size (kbytes): 0
Average unshared data size (kbytes): 0
Average stack size (kbytes): 0
Average total size (kbytes): 0
Maximum resident set size (kbytes): 392304
Average resident set size (kbytes): 0
Major (requiring I/O) page faults: 0
Minor (reclaiming a frame) page faults: 157699
Voluntary context switches: 464957
Involuntary context switches: 785465
Swaps: 0
File system inputs: 0
File system outputs: 0
Socket messages sent: 0
Socket messages received: 0
Signals delivered: 0
Page size (bytes): 4096
Exit status: 0
```
