### PR TITLE
fix: Skip policies with unknown GVR or policy-server URL

### DIFF
--- a/internal/policies/client_test.go
+++ b/internal/policies/client_test.go
@@ -173,6 +173,18 @@ func TestGetPoliciesForANamespace(t *testing.T) {
 		}).
 		Build()
 
+	// an AdmissionPolicy with unknown GVR, it should be errored and skipped
+	admissionPolicy5 := testutils.
+		NewAdmissionPolicyFactory().
+		Name("policy9").
+		Namespace("test").
+		Rule(admissionregistrationv1.Rule{
+			APIGroups:   []string{"apps"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"foo"},
+		}).
+		Build()
+
 	client, err := testutils.NewFakeClient(
 		namespace,
 		policyServer,
@@ -185,6 +197,7 @@ func TestGetPoliciesForANamespace(t *testing.T) {
 		admissionPolicy2,
 		admissionPolicy3,
 		admissionPolicy4,
+		admissionPolicy5,
 	)
 	require.NoError(t, err)
 
@@ -227,6 +240,7 @@ func TestGetPoliciesForANamespace(t *testing.T) {
 		},
 		PolicyNum:  2,
 		SkippedNum: 3,
+		ErroredNum: 1,
 	}
 
 	assert.Equal(t, expectedPolicies, policies)
@@ -339,6 +353,17 @@ func TestGetClusterWidePolicies(t *testing.T) {
 		Namespace("test").
 		Build()
 
+	// a ClusterAdmissionPolicy targeting unknown GVR, it should be errored and skipped
+	clusterAdmissionPolicy7 := testutils.
+		NewClusterAdmissionPolicyFactory().
+		Name("policy8").
+		Rule(admissionregistrationv1.Rule{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"foo"},
+		}).
+		Build()
+
 	client, err := testutils.NewFakeClient(
 		namespace,
 		policyServer,
@@ -350,6 +375,7 @@ func TestGetClusterWidePolicies(t *testing.T) {
 		clusterAdmissionPolicy5,
 		clusterAdmissionPolicy6,
 		admissionPolicy1,
+		clusterAdmissionPolicy7,
 	)
 	require.NoError(t, err)
 
@@ -382,6 +408,7 @@ func TestGetClusterWidePolicies(t *testing.T) {
 		},
 		PolicyNum:  3,
 		SkippedNum: 2,
+		ErroredNum: 1,
 	}
 
 	assert.Equal(t, expectedPolicies, policies)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -142,19 +142,22 @@ func (s *Scanner) ScanNamespace(ctx context.Context, nsName, runUID string) erro
 	}
 	policies, err := s.policiesClient.GetPoliciesForANamespace(ctx, nsName)
 	if err != nil {
+		log.Error().Err(err).Str("namespace", nsName).Msg("failed to obtain auditable policies")
 		return err
 	}
+
 	log.Info().
 		Str("namespace", nsName).
 		Dict("dict", zerolog.Dict().
 			Int("policies-to-evaluate", policies.PolicyNum).
-			Int("policies-skipped", policies.SkippedNum),
+			Int("policies-skipped", policies.SkippedNum).
+			Int("policies-errored", policies.ErroredNum),
 		).Msg("policy count")
 
 	for gvr, policies := range policies.PoliciesByGVR {
 		pager, err := s.k8sClient.GetResources(gvr, nsName)
 		if err != nil {
-			return err
+			log.Error().Err(err).Str("gvr", gvr.String()).Str("ns", nsName).Msg("failed to get resources")
 		}
 
 		err = pager.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -255,6 +255,7 @@ func (s *Scanner) ScanClusterWideResources(ctx context.Context, runUID string) e
 		Dict("dict", zerolog.Dict().
 			Int("policies-to-evaluate", policies.PolicyNum).
 			Int("policies-skipped", policies.SkippedNum).
+			Int("policies-errored", policies.ErroredNum).
 			Int("parallel-resources-audits", s.parallelResourcesAudits),
 		).Msg("cluster admission policies count")
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -211,6 +211,20 @@ func TestScanAllNamespaces(t *testing.T) {
 		}).
 		Status(policiesv1.PolicyStatusActive).
 		Build()
+
+	// an AdmissionPolicy targeting an unknown GVR, should error and be skipped
+	admissionPolicyUnknownGVR := testutils.
+		NewAdmissionPolicyFactory().
+		Name("policy6").
+		Namespace("namespace1").
+		Rule(admissionregistrationv1.Rule{
+			APIGroups:   []string{"apps"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"pods"},
+		}).
+		Status(policiesv1.PolicyStatusActive).
+		Build()
+
 	// add a policy report that should be deleted by the scanner
 	oldPolicyReportRunUID := uuid.New().String()
 	oldPolicyReport := testutils.NewPolicyReportFactory().
@@ -245,6 +259,7 @@ func TestScanAllNamespaces(t *testing.T) {
 		admissionPolicy2,
 		admissionPolicy3,
 		admissionPolicy4,
+		admissionPolicyUnknownGVR,
 		clusterAdmissionPolicy,
 		oldPolicyReport,
 	)
@@ -381,6 +396,19 @@ func TestScanClusterWideResources(t *testing.T) {
 		}).
 		Status(policiesv1.PolicyStatusActive).
 		Build()
+
+	// a ClusterAdmissionPolicy targeting an unknown GVR, should error and be skipped
+	clusterAdmissionPolicyUnknownGVR := testutils.
+		NewClusterAdmissionPolicyFactory().
+		Name("policy4").
+		Rule(admissionregistrationv1.Rule{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"foo"},
+		}).
+		Status(policiesv1.PolicyStatusActive).
+		Build()
+
 	// add a policy report that should be deleted by the scanner
 	oldClusterPolicyReportRunUID := uuid.New().String()
 	oldClusterPolicyReport := testutils.NewClusterPolicyReportFactory().
@@ -407,6 +435,7 @@ func TestScanClusterWideResources(t *testing.T) {
 		clusterAdmissionPolicy1,
 		clusterAdmissionPolicy2,
 		clusterAdmissionPolicy3,
+		clusterAdmissionPolicyUnknownGVR,
 		oldClusterPolicyReport,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/audit-scanner/issues/307

For policies that target an unknown GVR, or for which no valid
policy-server URL can be constructed, emit error logs and count them as
errored. Continue with the audit scan.

This is a regression fix from previous audit-scanner 1.11 refactor.

For that, add new `Policies.ErroredNum` field. This errored tally will get
printed in the logs, but can't be printed in (Cluster)PolicyReports, as there's
no report created for an unknown unexistent resource.

Note that policies that target an unknown GVR may be incorrectly configured,
or may have been correctly configured against a CRD, but the CRD has been removed by now.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added unit tests, CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

With the current (Cluster)PolicyReport data structures, it isn't possible to save an error on them for policies that target an unknown GVR.


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
