### PR TITLE
fix: Propagate skipped,errored numbers from audited policies

### DIFF
--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -44,6 +44,9 @@ func TestNewPolicyReport(t *testing.T) {
 	assert.Equal(t, types.UID("uid"), policyReport.Scope.UID)
 	assert.Equal(t, "12345", policyReport.Scope.ResourceVersion)
 
+	assert.Equal(t, 1, policyReport.Summary.Skip)
+	assert.Equal(t, 1, policyReport.Summary.Error)
+
 	assert.Empty(t, policyReport.Results)
 }
 
@@ -93,6 +96,9 @@ func TestNewClusterPolicyReport(t *testing.T) {
 	assert.Equal(t, "test-namespace", clusterPolicyReport.Scope.Name)
 	assert.Equal(t, types.UID("uid"), clusterPolicyReport.Scope.UID)
 	assert.Equal(t, "12345", clusterPolicyReport.Scope.ResourceVersion)
+
+	assert.Equal(t, 1, clusterPolicyReport.Summary.Skip)
+	assert.Equal(t, 1, clusterPolicyReport.Summary.Error)
 
 	assert.Empty(t, clusterPolicyReport.Results)
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -24,6 +24,8 @@ func TestNewPolicyReport(t *testing.T) {
 	resource.SetResourceVersion("12345")
 
 	policyReport := NewPolicyReport("runUID", resource)
+	policyReport.Summary.Skip = 1
+	policyReport.Summary.Error = 1
 
 	assert.Equal(t, "uid", policyReport.ObjectMeta.Name)
 	assert.Equal(t, "namespace", policyReport.ObjectMeta.Namespace)
@@ -73,6 +75,8 @@ func TestNewClusterPolicyReport(t *testing.T) {
 	resource.SetResourceVersion("12345")
 
 	clusterPolicyReport := NewClusterPolicyReport("runUID", resource)
+	clusterPolicyReport.Summary.Skip = 1
+	clusterPolicyReport.Summary.Error = 1
 
 	assert.Equal(t, "uid", clusterPolicyReport.ObjectMeta.Name)
 	assert.Equal(t, "kubewarden", clusterPolicyReport.ObjectMeta.Labels[labelAppManagedBy])


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix  https://github.com/kubewarden/audit-scanner/issues/337


When we get all auditable policies for a namespace (or clusterwide) we
have a number of skipped policies (those skipped because of constraints
like no * in GVR) and a number of errored policies (unknown GVR for
example).

Propagate those numbers to the creation of the (Cluster)PolicyReport
for its `spec.Summary`.

Note: when we audit resources later on, we can have errored or skipped
policies, those get added to `spec.Summary` at that time.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
