### PR TITLE
fix: Correctly log errors on creating AdmissionReview instead of panic

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -141,7 +141,9 @@ func newPolicyReportResult(policy policiesv1.Policy, admissionReview *admissionv
 	// optional. If the policy returns "allowed" to the admissionReview,
 	// the Result field is not checked by Kubernetes.
 	// https://pkg.go.dev/k8s.io/api@v0.29.2/admission/v1#AdmissionResponse
-	if admissionReview.Response != nil && admissionReview.Response.Result != nil {
+	if admissionReview != nil &&
+		admissionReview.Response != nil &&
+		admissionReview.Response.Result != nil {
 		// Mesage contains the human-readable error message if Response.Result.Code == 500
 		// or the reason why the policy returned a failure
 		message = admissionReview.Response.Result.Message

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -352,9 +352,7 @@ func (s *Scanner) auditResource(ctx context.Context, policies []*policies.Policy
 					Str("policy", policy.GetName()).
 					Str("resource", resource.GetName()),
 				).Msg("error sending AdmissionReview to PolicyServer")
-			}
-
-			if admissionReviewResponse.Response.Result != nil &&
+			} else if admissionReviewResponse.Response.Result != nil &&
 				admissionReviewResponse.Response.Result.Code == 500 {
 				errored = true
 				// log Result.Message, will end in PolicyReportResult too
@@ -446,9 +444,7 @@ func (s *Scanner) auditClusterResource(ctx context.Context, policies []*policies
 				Str("resource", resource.GetName()),
 			).
 				Msg("error sending AdmissionReview to PolicyServer")
-		}
-
-		if admissionReviewResponse.Response.Result != nil &&
+		} else if admissionReviewResponse.Response.Result != nil &&
 			admissionReviewResponse.Response.Result.Code == 500 {
 			errored = true
 			// log Result.Message, will end in PolicyReportResult too


### PR DESCRIPTION
## Description

If not, errors on creating an AdmissionReview get logged but we continue. Given that we don't have an AdmissionReview, we would panic on `report.newPolicyReportResult()`.

Example:

```console
{"level":"error","error":"unexpected status code: 500 body: {\"message\":\"Something went wrong\",\"status\":500}","response":{"admissionRequest-name":"nginx-with-secrets","policy":"pod-image-signatures","resource":"nginx-with-secrets"},"time":"2024-09-11T16:34:41+02:00","message":"error sending AdmissionReview to PolicyServer"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1b59592]

goroutine 163 [running]:
github.com/kubewarden/audit-scanner/internal/report.newPolicyReportResult({0x23f4488, 0xc0001c1c00}, 0x0, 0x1, {0xc00074ddf8?, 0x409952?})
        /home/vic/suse/kw/audit-scanner/internal/report/report.go:144 +0x52
github.com/kubewarden/audit-scanner/internal/report.AddResultToPolicyReport(0xc0003ae420, {0x23f4488, 0xc0001c1c00}, 0x0, 0x1)
        /home/vic/suse/kw/audit-scanner/internal/report/report.go:61 +0x77
github.com/kubewarden/audit-scanner/internal/scanner.(*Scanner).auditResource(0xc000278b60, {0x23bcd80, 0x35c2280}, {0xc0006eccb0, 0x1, 0x0?}, {0xc000571bc0}, {0xc000798630, 0x24}, 0x0, ...)
        /home/vic/suse/kw/audit-scanner/internal/scanner/scanner.go:390 +0x497
github.com/kubewarden/audit-scanner/internal/scanner.(*Scanner).ScanNamespace.func1.1()
        /home/vic/suse/kw/audit-scanner/internal/scanner/scanner.go:178 +0xd9
created by github.com/kubewarden/audit-scanner/internal/scanner.(*Scanner).ScanNamespace.func1 in goroutine 1
        /home/vic/suse/kw/audit-scanner/internal/scanner/scanner.go:174 +0x1a9
````





<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Discovered and tested locally, by using PolicyGroups on rc1.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
