### PR TITLE
feat: add mTLS support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,6 +156,7 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 	rootCmd.Flags().StringP("extra-ca", "f", "", "File path to CA cert in PEM format of PolicyServer endpoints")
 	rootCmd.Flags().StringP("client-cert", "", "", "File path to client cert in PEM format used for mTLS communication with the PolicyServer endpoints")
 	rootCmd.Flags().StringP("client-key", "", "", "File path to client key in PEM format used for mTLS communication with the PolicyServer endpoints")
+	rootCmd.MarkFlagsRequiredTogether("client-cert", "client-key")
 	rootCmd.Flags().BoolVar(&disableStore, "disable-store", false, "disable storing the results in the k8s cluster")
 	rootCmd.Flags().IntP("parallel-namespaces", "", defaultParallelNamespaces, "number of Namespaces to scan in parallel")
 	rootCmd.Flags().IntP("parallel-resources", "", defaultParallelResources, "number of resources to scan in parallel")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,7 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 			if err != nil {
 				return err
 			}
-			caCertFile, err := cmd.Flags().GetString("extra-ca")
+			caFile, err := cmd.Flags().GetString("extra-ca")
 			if err != nil {
 				return err
 			}
@@ -113,11 +113,27 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 				return err
 			}
 			policyReportStore := report.NewPolicyReportStore(client)
-			scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL,
-				caCertFile, clientCertFile, clientKeyFile,
-				parallelNamespacesAudits,
-				parallelResourcesAudits,
-				parallelPoliciesAudit)
+
+			scannerConfig := scanner.Config{
+				PoliciesClient:    policiesClient,
+				K8sClient:         k8sClient,
+				PolicyReportStore: policyReportStore,
+				TLS: scanner.TLSConfig{
+					Insecure:       insecureSSL,
+					CAFile:         caFile,
+					ClientCertFile: clientCertFile,
+					ClientKeyFile:  clientKeyFile,
+				},
+				Parallelization: scanner.ParallelizationConfig{
+					ParallelNamespacesAudits: parallelNamespacesAudits,
+					ParallelResourcesAudits:  parallelResourcesAudits,
+					PoliciesAudits:           parallelPoliciesAudit,
+				},
+				OutputScan:   outputScan,
+				DisableStore: disableStore,
+			}
+
+			scanner, err := scanner.NewScanner(scannerConfig)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,7 @@ const (
 	defaultPageSize            = 100
 )
 
-//nolint:gocognit
+//nolint:gocognit,funlen // This function is the CLI entrypoint and it's expected to be long.
 func NewRootCommand() *cobra.Command {
 	var (
 		level        logconfig.Level // log level.
@@ -64,6 +64,14 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 				return err
 			}
 			caCertFile, err := cmd.Flags().GetString("extra-ca")
+			if err != nil {
+				return err
+			}
+			clientCertFile, err := cmd.Flags().GetString("client-cert")
+			if err != nil {
+				return err
+			}
+			clientKeyFile, err := cmd.Flags().GetString("client-key")
 			if err != nil {
 				return err
 			}
@@ -105,7 +113,8 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 				return err
 			}
 			policyReportStore := report.NewPolicyReportStore(client)
-			scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL, caCertFile,
+			scanner, err := scanner.NewScanner(policiesClient, k8sClient, policyReportStore, outputScan, disableStore, insecureSSL,
+				caCertFile, clientCertFile, clientKeyFile,
 				parallelNamespacesAudits,
 				parallelResourcesAudits,
 				parallelPoliciesAudit)
@@ -129,6 +138,8 @@ There will be a ClusterPolicyReport with results for cluster-wide resources.`,
 	rootCmd.Flags().StringSliceVarP(&skippedNs, "ignore-namespaces", "i", nil, "comma separated list of namespace names to be skipped from scan. This flag can be repeated")
 	rootCmd.Flags().BoolVar(&insecureSSL, "insecure-ssl", false, "skip SSL cert validation when connecting to PolicyServers endpoints. Useful for development")
 	rootCmd.Flags().StringP("extra-ca", "f", "", "File path to CA cert in PEM format of PolicyServer endpoints")
+	rootCmd.Flags().StringP("client-cert", "", "", "File path to client cert in PEM format used for mTLS communication with the PolicyServer endpoints")
+	rootCmd.Flags().StringP("client-key", "", "", "File path to client key in PEM format used for mTLS communication with the PolicyServer endpoints")
 	rootCmd.Flags().BoolVar(&disableStore, "disable-store", false, "disable storing the results in the k8s cluster")
 	rootCmd.Flags().IntP("parallel-namespaces", "", defaultParallelNamespaces, "number of Namespaces to scan in parallel")
 	rootCmd.Flags().IntP("parallel-resources", "", defaultParallelResources, "number of resources to scan in parallel")

--- a/internal/scanner/config.go
+++ b/internal/scanner/config.go
@@ -1,0 +1,32 @@
+package scanner
+
+import (
+	"github.com/kubewarden/audit-scanner/internal/k8s"
+	"github.com/kubewarden/audit-scanner/internal/policies"
+	"github.com/kubewarden/audit-scanner/internal/report"
+)
+
+type ParallelizationConfig struct {
+	ParallelNamespacesAudits int
+	ParallelResourcesAudits  int
+	PoliciesAudits           int
+}
+
+type TLSConfig struct {
+	Insecure       bool
+	CAFile         string
+	ClientCertFile string
+	ClientKeyFile  string
+}
+
+type Config struct {
+	PoliciesClient    *policies.Client
+	K8sClient         *k8s.Client
+	PolicyReportStore *report.PolicyReportStore
+
+	TLS             TLSConfig
+	Parallelization ParallelizationConfig
+
+	OutputScan   bool
+	DisableStore bool
+}


### PR DESCRIPTION
## Description

Part of: #462 

This PR introduces the `client-cert` and `client-key` flags, which specify the certificate file paths for mTLS communication with PolicyServer endpoints. 


Additionally, it refactors the `Scanner` constructor by introducing a `Config` type to manage the growing number of constructor parameters.