### PR TITLE
ci: fix attestation generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,29 +134,38 @@ jobs:
             jq '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
           echo "SBOM_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
 
+      # We need to upload provenance and SBOM files, plus their signatures under the GitHub Release page.
+      # Moreover, the files have to be named in a certain way.
+      # This is required by [ossf](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases)
       - name: Download provenance and SBOM files
         run: |
           set -e
-          crane blob ghcr.io/${{github.repository_owner}}/audit-scanner@${{ env.PROVENANCE_DIGEST}} > audit-scanner-attestation-${{ matrix.arch }}-provenance.json
-          sha256sum audit-scanner-attestation-${{ matrix.arch }}-provenance.json >> audit-scanner-attestation-${{ matrix.arch }}-checksum.txt
+          crane blob ghcr.io/${{github.repository_owner}}/audit-scanner@${{ env.PROVENANCE_DIGEST}} \
+            > audit-scanner-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
 
+          crane blob ghcr.io/${{github.repository_owner}}/audit-scanner@${{ env.SBOM_DIGEST}} \
+            > audit-scanner-attestation-${{ matrix.arch }}-sbom.json
 
-          for sbom_digest in "${{ env.SBOM_DIGEST }}"; do
-            crane blob ghcr.io/${{github.repository_owner}}/audit-scanner@$sbom_digest > audit-scanner-attestation-${{ matrix.arch }}-sbom-${sbom_digest#"sha256:"}.json
-            sha256sum audit-scanner-attestation-${{ matrix.arch }}-sbom-${sbom_digest#"sha256:"}.json >> audit-scanner-attestation-${{ matrix.arch }}-checksum.txt
-          done
-
-      - name: Sign checksum file
+      - name: Sign provenance and SBOM files
         run: |
+          set -e
           cosign sign-blob --yes \
-            --bundle audit-scanner-attestation-${{ matrix.arch }}-checksum-cosign.bundle \
-            audit-scanner-attestation-${{ matrix.arch }}-checksum.txt
-            
+            --bundle audit-scanner-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
+            audit-scanner-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
           cosign verify-blob \
-            --bundle audit-scanner-attestation-${{ matrix.arch }}-checksum-cosign.bundle \
+            --bundle audit-scanner-attestation-${{ matrix.arch }}-provenance.intoto.jsonl.bundle.sigstore \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
             --certificate-identity="https://github.com/${{github.repository_owner}}/audit-scanner/.github/workflows/release.yml@${{ github.ref }}" \
-            audit-scanner-attestation-${{ matrix.arch }}-checksum.txt
+            audit-scanner-attestation-${{ matrix.arch }}-provenance.intoto.jsonl
+
+          cosign sign-blob --yes \
+            --bundle audit-scanner-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
+            audit-scanner-attestation-${{ matrix.arch }}-sbom.json
+          cosign verify-blob \
+            --bundle audit-scanner-attestation-${{ matrix.arch }}-sbom.json.bundle.sigstore \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity="https://github.com/${{github.repository_owner}}/audit-scanner/.github/workflows/release.yml@${{ github.ref }}" \
+            audit-scanner-attestation-${{ matrix.arch }}-sbom.json
 
       - name: Upload SBOMs as artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -271,8 +280,14 @@ jobs:
             let path = require('path');
 
             let files = [
-              'attestation-amd64.tar.gz',
-              'attestation-arm64.tar.gz',
+              'audit-scanner-attestation-amd64-provenance.intoto.jsonl',
+              'audit-scanner-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
+              'audit-scanner-attestation-arm64-provenance.intoto.jsonl',
+              'audit-scanner-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+              'audit-scanner-attestation-amd64-sbom.json',
+              'audit-scanner-attestation-amd64-sbom.json.bundle.sigstore',
+              'audit-scanner-attestation-arm64-sbom.json',
+              'audit-scanner-attestation-arm64-sbom.json.bundle.sigstore',
               "CRDS.tar.gz"]
             const {RELEASE_ID} = process.env
 


### PR DESCRIPTION
Some components of the kubewarden project were failing at release time because of a change introduced by cosign v3.

Surprisingly, audit-scanner release was NOT failing. That happened because its automation pipeline was NOT signing provenance and SBOM attestations.

This PR adopts the same approach used by the other components of the Kubewarden stack. It ensures the provenance and SBOM files are signed and are part of the GitHub Release as **individual** assets.
The latter point is something required by openssf.
